### PR TITLE
CIWEMB-61: Create and Set Contribution owner orgnisation

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/Post/ContributionCreation.php
+++ b/CRM/Multicompanyaccounting/Hook/Post/ContributionCreation.php
@@ -1,0 +1,42 @@
+<?php
+
+class CRM_Multicompanyaccounting_Hook_Post_ContributionCreation {
+
+  private $contributionId;
+
+  public function __construct($contributionId) {
+    $this->contributionId = $contributionId;
+  }
+
+  public function run() {
+    $this->updateOwnerOrganization();
+  }
+
+  private function updateOwnerOrganization() {
+    $ownerOrganizationId = $this->getOwnerOrganizationId();
+    if (!empty($ownerOrganizationId)) {
+      $updateQuery = "INSERT INTO civicrm_value_multicompanyaccounting_ownerorg (entity_id, owner_organization)
+                    VALUES ({$this->contributionId}, {$ownerOrganizationId})
+                    ON DUPLICATE KEY UPDATE owner_organization = {$ownerOrganizationId}";
+      CRM_Core_DAO::executeQuery($updateQuery);
+    }
+  }
+
+  /**
+   * Gets the owner organization Id,
+   * which comes from the owner of the
+   * first line item income account.
+   *
+   * @return string|null
+   */
+  private function getOwnerOrganizationId() {
+    $incomeAccountRelationId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Income Account is' "));
+    $OwnerOrgQuery = "SELECT fa.contact_id FROM civicrm_line_item li
+                      INNER JOIN civicrm_entity_financial_account efa ON li.financial_type_id = efa.entity_id AND efa.entity_table = 'civicrm_financial_type'
+                      INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
+                      WHERE efa.account_relationship = {$incomeAccountRelationId} AND li.contribution_id = {$this->contributionId}
+                      LIMIT 1";
+    return CRM_Core_DAO::singleValueQuery($OwnerOrgQuery);
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Setup/CustomGroup/ContributionOwnerOrganization.php
+++ b/CRM/Multicompanyaccounting/Setup/CustomGroup/ContributionOwnerOrganization.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Managing 'Contribution Owner Organization' custom group and its fields.
+ */
+class CRM_Multicompanyaccounting_Setup_CustomGroup_ContributionOwnerOrganization {
+
+  public function create() {
+    // nothing to do here, the custom group will be created automatically
+    // because it is defined in the extension XML files.
+  }
+
+  public function remove() {
+    $customFields = [
+      'owner_organization',
+    ];
+    foreach ($customFields as $customFieldName) {
+      civicrm_api3('CustomField', 'get', [
+        'name' => $customFieldName,
+        'custom_group_id' => 'multicompanyaccounting_contribution_owner',
+        'api.CustomField.delete' => ['id' => '$value.id'],
+      ]);
+    }
+
+    civicrm_api3('CustomGroup', 'get', [
+      'name' => 'multicompanyaccounting_contribution_owner',
+      'api.CustomGroup.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  public function toggle($status) {
+    civicrm_api3('CustomGroup', 'get', [
+      'name' => 'multicompanyaccounting_contribution_owner',
+      'api.CustomGroup.create' => ['id' => '$value.id', 'is_active' => $status],
+    ]);
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Upgrader.php
+++ b/CRM/Multicompanyaccounting/Upgrader.php
@@ -5,4 +5,31 @@
  */
 class CRM_Multicompanyaccounting_Upgrader extends CRM_Multicompanyaccounting_Upgrader_Base {
 
+  public function enable() {
+    $steps = [
+      new CRM_Multicompanyaccounting_Setup_CustomGroup_ContributionOwnerOrganization(),
+    ];
+    foreach ($steps as $step) {
+      $step->toggle(TRUE);
+    }
+  }
+
+  public function disable() {
+    $steps = [
+      new CRM_Multicompanyaccounting_Setup_CustomGroup_ContributionOwnerOrganization(),
+    ];
+    foreach ($steps as $step) {
+      $step->toggle(FALSE);
+    }
+  }
+
+  public function uninstall() {
+    $removalSteps = [
+      new CRM_Multicompanyaccounting_Setup_CustomGroup_ContributionOwnerOrganization(),
+    ];
+    foreach ($removalSteps as $step) {
+      $step->remove();
+    }
+  }
+
 }

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -155,3 +155,10 @@ function multicompanyaccounting_civicrm_navigationMenu(&$menu) {
 
   _membershipextras_civix_insert_navigation_menu($menu, 'Administer/CiviContribute', $companyMenuItem);
 }
+
+function multicompanyaccounting_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef) {
+  if ($objectName === 'Contribution' && $op === 'create') {
+    $hook = new CRM_Multicompanyaccounting_Hook_Post_ContributionCreation($objectId);
+    $hook->run();
+  }
+}

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/Post/ContributionCreationTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/Post/ContributionCreationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_Post_ContributionCreationTest extends BaseHeadlessTest {
+
+  public function testOwnerOrganizationIsSetToFirstLineItemIncomeAccountOwner() {
+    $firstOrg = $this->createOrganization('testorg1');
+    $firstFinancialType = $this->updateFinancialAccountOwner('Donation', $firstOrg['id']);
+
+    $secondOrg = $this->createOrganization('testorg2');
+    $secondFinancialType = $this->updateFinancialAccountOwner('Member Dues', $secondOrg['id']);
+
+    $params = [
+      'price_field_id' => 1,
+      'label' => 'Price Field 2',
+      'amount' => 100,
+      'financial_type_id' => 'Donation',
+    ];
+    $secondPriceFieldValue = civicrm_api3('PriceFieldValue', 'create', $params);
+
+    // Creating order with two line items,
+    // where each line item has different
+    // financial_type_id
+    $orderParams = [
+      'contact_id' => 1,
+      'financial_type_id' => 'Donation',
+      'contribution_status_id' => 'Pending',
+      'line_items' => [
+        '0' => [
+          'line_item' => [
+            '0' => [
+              'price_field_id' => '1',
+              'price_field_value_id' => '1',
+              'label' => 'Price Field 1',
+              'field_title' => 'Price Field 1',
+              'qty' => 1,
+              'unit_price' => '100',
+              'line_total' => '100',
+              'financial_type_id' => $secondFinancialType['id'],
+              'entity_table' => 'civicrm_contribution',
+            ],
+          ],
+        ],
+        '1' => [
+          'line_item' => [
+            '0' => [
+              'price_field_id' => '1',
+              'price_field_value_id' => $secondPriceFieldValue['id'],
+              'label' => 'Price Field 2',
+              'field_title' => 'Price Field 2',
+              'qty' => 1,
+              'unit_price' => '100',
+              'line_total' => '100',
+              'financial_type_id' => $firstFinancialType['id'],
+              'entity_table' => 'civicrm_contribution',
+            ],
+          ],
+        ],
+      ],
+    ];
+    $order = civicrm_api3('Order', 'create', $orderParams);
+
+    $contributionId = key($order['values']);
+    $contributionOwnerOrgId = $this->getContributionOwnerOrgId($contributionId);
+
+    $this->assertEquals($secondOrg['id'], $contributionOwnerOrgId);
+  }
+
+  private function createOrganization($orgName) {
+    return civicrm_api3('Contact', 'create', [
+      'sequential' => 1,
+      'contact_type' => 'Organization',
+      'organization_name' => $orgName,
+    ])['values'][0];
+  }
+
+  private function updateFinancialAccountOwner($accountName, $newOwnerId) {
+    return civicrm_api3('FinancialAccount', 'get', [
+      'sequential' => 1,
+      'name' => $accountName,
+      'api.FinancialAccount.create' => ['id' => '$value.id', 'contact_id' => $newOwnerId],
+    ])['values'][0];
+  }
+
+  private function getContributionOwnerOrgId($contributionId) {
+    $ownerOrgCgId = civicrm_api3('CustomField', 'getvalue', [
+      'return' => 'id',
+      'custom_group_id' => 'multicompanyaccounting_contribution_owner',
+      'name' => 'owner_organization',
+    ]);
+
+    return civicrm_api3('Contribution', 'getvalue', [
+      'return' => "custom_$ownerOrgCgId",
+      'id' => $contributionId,
+    ]);
+  }
+
+}

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<CustomData>
+    <CustomGroups>
+        <CustomGroup>
+            <name>multicompanyaccounting_contribution_owner</name>
+            <title>Contribution Owner Organization</title>
+            <extends>Contribution</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_multicompanyaccounting_ownerorg</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+            <is_reserved>1</is_reserved>
+        </CustomGroup>
+    </CustomGroups>
+    <CustomFields>
+      <CustomField>
+        <name>owner_organization</name>
+        <label>Owner Organization</label>
+        <data_type>ContactReference</data_type>
+        <html_type>Autocomplete-Select</html_type>
+        <is_required>0</is_required>
+        <is_searchable>1</is_searchable>
+        <is_search_range>0</is_search_range>
+        <weight>1</weight>
+        <is_active>1</is_active>
+        <is_view>1</is_view>
+        <text_length>255</text_length>
+        <note_columns>60</note_columns>
+        <note_rows>4</note_rows>
+        <column_name>owner_organization</column_name>
+        <in_selector>0</in_selector>
+        <custom_group_name>multicompanyaccounting_contribution_owner</custom_group_name>
+      </CustomField>
+    </CustomFields>
+</CustomData>


### PR DESCRIPTION
## Before

---

## After

To help supporting multi companies accounting, a new custom group/field is added to the Contribution entity called "Owner Organization", This field is "reserved" and "view only", and is set automatically by this extension (using hook_civicrm_post) when a contribution is created  whether from new contribution form or new membership form, or any other places in Civi that allow contributions to be created.

The contribution owner organization is set to be the owner of the income account for the first line item in the created contribution.

Here is an example price set with two line items, each belong to different financial  type: 
![image](https://user-images.githubusercontent.com/6275540/205640418-51fdcdaa-7bef-4287-98db-802475b42ee2.png)

And here I set the owner of the income account for each financial type to be different:

![aa](https://user-images.githubusercontent.com/6275540/205639968-2505924a-576f-4cba-a67a-f3958f1c4a09.png)

Now when creating new contribution with this price set and selecting both line items above:
![image](https://user-images.githubusercontent.com/6275540/205640518-610eaf1c-f3c0-4aa8-8b80-64b54509f0c7.png)

The first line item income account owner was set to be the owner organization for the contribution:

![2022-12-05 15_46_03-test111 test111 _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/205640695-767ad7af-f67d-4940-ae1c-83d5d85784f4.png)
