### PR TITLE
CIWEMB-57: Add owner organisations filter to batch list page

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialBatchSearch.php
+++ b/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialBatchSearch.php
@@ -1,0 +1,33 @@
+<?php
+
+use CRM_Multicompanyaccounting_ExtensionUtil as ExtensionUtil;
+
+class CRM_Multicompanyaccounting_Hook_BuildForm_FinancialBatchSearch {
+
+  private $form;
+
+  public function __construct($form) {
+    $this->form = $form;
+  }
+
+  public function run() {
+    $this->addOwnerOrganisationFilterField();
+  }
+
+  private function addOwnerOrganisationFilterField() {
+    // adds the owner org field element to the QuickForm instance
+    $this->form->addEntityRef('multicompanyaccounting_owner_org_id', ts('Owner Organisation(s)'), [
+      'api' => ['params' => ['contact_type' => 'Organization']],
+      'select' => ['minimumInputLength' => 0],
+      'placeholder' => ts('Select Owner Organisation(s)'),
+      'multiple' => TRUE,
+    ], FALSE);
+
+    // adds the HTML markup to the form
+    $templatePath = ExtensionUtil::path() . '/templates';
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$templatePath}/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialBatchSearch.tpl",
+    ]);
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Hook/Config/APIWrapper/BatchListPage.php
+++ b/CRM/Multicompanyaccounting/Hook/Config/APIWrapper/BatchListPage.php
@@ -1,0 +1,45 @@
+<?php
+
+class CRM_Multicompanyaccounting_Hook_Config_APIWrapper_BatchListPage {
+
+  /**
+   * Callback precedes batch.get and batch.getcount
+   * API calls but only ony the financial batches list page.
+   *
+   * See: https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/#migrating-away-from-this-hook
+   */
+  public static function preApiCall($event) {
+    // make sure this only runs on the financial batches list page.
+    $referer = CRM_Utils_System::refererPath();
+    if (strpos($referer, 'civicrm/financial/financialbatches') === FALSE) {
+      return;
+    }
+
+    // make sure this only runs on batch.get and batch.getcount APIs
+    $apiRequestSig = $event->getApiRequestSig();
+    if (!in_array($apiRequestSig, ['3.batch.get', '3.batch.getcount'])) {
+      return;
+    }
+
+    $event->wrapAPI(['CRM_Multicompanyaccounting_Hook_Config_APIWrapper_BatchListPage', 'enforcePermissionCheck']);
+  }
+
+  /**
+   * Enforces permission check on batch.get
+   * and batch.getcount API calls.
+   * This is needed because otherwise we won't
+   * be able to use hook_civicrm_selectWhereClause that
+   * we use to do filter batches list based on the
+   * owner organisations filter.
+   * See: https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_selectWhereClause/#notes
+   *
+   * @param array $apiRequest
+   * @param array $callsame
+   */
+  public function enforcePermissionCheck(&$apiRequest, $callsame) {
+    $apiRequest['params']['check_permissions'] = 1;
+
+    return $callsame($apiRequest);
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Hook/SelectWhereClause/BatchList.php
+++ b/CRM/Multicompanyaccounting/Hook/SelectWhereClause/BatchList.php
@@ -1,0 +1,22 @@
+<?php
+
+class CRM_Multicompanyaccounting_Hook_SelectWhereClause_BatchList {
+
+  private $whereClause;
+
+  public function __construct(&$whereClause) {
+    $this->whereClause = &$whereClause;
+  }
+
+  /**
+   * Filters the batches in the batch list
+   * page based on the selected owner organisations.
+   *
+   * @param $ownerOrganisationToFilterIds
+   *   Comma seperated organisation ids
+   */
+  public function filterBasedOnOwnerOrganisations($ownerOrganisationToFilterIds) {
+    $this->whereClause['id'][] = "IN (SELECT batch_id FROM multicompanyaccounting_batch_owner_org WHERE owner_org_id IN ($ownerOrganisationToFilterIds))";
+  }
+
+}

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -12,6 +12,8 @@ use CRM_Multicompanyaccounting_ExtensionUtil as E;
  */
 function multicompanyaccounting_civicrm_config(&$config) {
   _multicompanyaccounting_civix_civicrm_config($config);
+
+  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Multicompanyaccounting_Hook_Config_APIWrapper_BatchListPage', 'preApiCall']);
 }
 
 /**
@@ -174,6 +176,11 @@ function multicompanyaccounting_civicrm_buildForm($formName, &$form) {
     $hook = new CRM_Multicompanyaccounting_Hook_BuildForm_BatchTransaction($form);
     $hook->run();
   }
+
+  if ($formName == 'CRM_Financial_Form_Search') {
+    $hook = new CRM_Multicompanyaccounting_Hook_BuildForm_FinancialBatchSearch($form);
+    $hook->run();
+  }
 }
 
 function multicompanyaccounting_civicrm_postProcess($formName, $form) {
@@ -187,5 +194,13 @@ function multicompanyaccounting_civicrm_alterContent(&$content, $context, $tplNa
   if ($tplName == 'CRM/Financial/Page/BatchTransaction.tpl') {
     $hook = new CRM_Multicompanyaccounting_Hook_AlterContent_BatchTransaction($content);
     $hook->run();
+  }
+}
+
+function multicompanyaccounting_civicrm_selectWhereClause($entity, &$clauses) {
+  $ownerOrganisationToFilterIds = CRM_Utils_Request::retrieve('multicompanyaccounting_owner_org_id', 'CommaSeparatedIntegers');
+  if ($entity == 'Batch' && !empty($ownerOrganisationToFilterIds)) {
+    $hook = new CRM_Multicompanyaccounting_Hook_SelectWhereClause_BatchList($clauses);
+    $hook->filterBasedOnOwnerOrganisations($ownerOrganisationToFilterIds);
   }
 }

--- a/templates/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialBatchSearch.tpl
+++ b/templates/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialBatchSearch.tpl
@@ -1,0 +1,33 @@
+<table id="multicompanyaccounting_owner_org_table" class="form-layout">
+  <tbody>
+  <tr id="multicompanyaccounting_owner_org_row">
+    <td class="label">
+        {$form.multicompanyaccounting_owner_org_id.label}
+    </td>
+    <td>
+        {$form.multicompanyaccounting_owner_org_id.html}
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+{literal}
+  <script type="text/javascript">
+    CRM.$('#multicompanyaccounting_owner_org_row').insertAfter('tr.crm-financial-search-form-block-total');
+
+    // Batch list page uses AJAX to filter the batch list,
+    // but changes in the owner organisations field do
+    // not trigger the filtration AJAX, because it is
+    // added here in this template and not native to the
+    // batch filtration form, to solve this, here we trigger
+    // a "change" request on one of the native batch
+    // filters (the batch title filter) in case any change
+    // happens on the owner organisations field.
+    CRM.$('#multicompanyaccounting_owner_org_row :input')
+      .change(function() {
+        if (!CRM.$(this).hasClass('crm-inline-error')) {
+          CRM.$('input #title').trigger('change');
+        }
+      })
+  </script>
+{/literal}


### PR DESCRIPTION
## Overview

The specs document talks about adding the owner orgnisation filter both as an input field and in the results table:
![image](https://user-images.githubusercontent.com/6275540/207646968-7b9412c4-00fc-4030-84ab-fe6cf7109f3e.png)

In this PR I am only adding the ability to filter batches in the batch list by their owner organisation(s), without the ability to see the owner organisation name in search results table, for technical reasons that I will discuss in the technical details section below.

## Before

There is no place to filter batches by their owner organisation. 

![image](https://user-images.githubusercontent.com/6275540/207645119-a8021c96-74ba-4e48-971e-d3f2c49080f6.png)

## After

"Owner Organisation(s)." a multi select, auotcomplete field is added, that allow users to filter batches by owner organisation, the filtration happen using AJAX same as with other filters on the page.

![ezgif-1-cb25997477](https://user-images.githubusercontent.com/6275540/207645667-c21a0d76-a48b-4b7b-92f4-92253ed37568.gif)


## Technical Details

The batch list page is a CiviCRM  core page, which is implemented here:
- https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Financial/Form/Search.php
- https://github.com/civicrm/civicrm-core/blob/5.39.1/templates/CRM/Financial/Form/Search.tpl

And it relies on AJAX requests to filter the result if any input in the search form changes:

- https://github.com/civicrm/civicrm-core/blob/5.39.1/templates/CRM/Financial/Form/Search.tpl#L59-L71
- https://github.com/civicrm/civicrm-core/blob/5.39.1/templates/CRM/Financial/Form/Search.tpl#L76

where these AJAX requests end up calling this method: https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Batch/Page/AJAX.php#L40 (CRM_Batch_Page_AJAX::getBatchList)


In my PR here I  Injected the owner organisation(s) field to the above page using BuildForm hook.

And to make batches get filtered, I had to rely on the fact that `CRM_Batch_Page_AJAX::getBatchList` ends up calling `CRM_Batch_BAO_Batch::getBatchList(&$params);`  which relies on calling the Batch v3 API to get the batches list, so I made use of that and  Implemented `hook_civicrm_selectWhereClause` hook, where I check if there is any organisation selected and add a where statement to filter the batches based on that selection.  but given as written here: https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_selectWhereClause/#notes this hook only gets called when `check_permissions` API parameter is set to TRUE, I ended up implementing `hook_civicrm_config` to create an API wrapper (see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/#migrating-away-from-this-hook) that is used to inject `check_permission` = true on the `Batch.get` and `Batch.getcount` API calls, only in case these calls are coming from the batches list page.


Now the reason I did not add the "Owner Organisation" to the results table itself, is because showing the “Owner Org” column is a bit complex to implement, and it would require either one of the following:

1- Some sort of core overrides, because the table columns are hardcoded and I will have to override `CRM_Batch_Page_AJAX::getBatchList` and some other methods to get around that.
2- Or replacing the screen with a new one that our extension provides, which is also a a lot work. Also using searchkit/form builder does not work given actions like "Close", "Cancel" and "Reopen" a batch are implement in Javascript, which at the moment are hard to implement with searchkit/formbuilder.
3- Or rewriting the form in core to make it more easier to customize in extensions, but it is a bit complex and time consuming todo.

Thus I  think we can ignore it as long the “Owner Org” field filter exist  on the filters form and work fine (which is basically what this PR does), But I asked this quesiton on the specs document too and will wait for others thoughts, if we agreed it worth spending time to do any of the above 3 solutions, then I will create another PR.

