### PR TITLE
CIWEMB-54: Restrict owner field on financial account to only legal en…

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialAccount.php
+++ b/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialAccount.php
@@ -1,0 +1,33 @@
+<?php
+
+class CRM_Multicompanyaccounting_Hook_BuildForm_FinancialAccount {
+
+  private $form;
+
+  public function __construct($form) {
+    $this->form = $form;
+  }
+
+  public function run() {
+    $this->restrictOwnerFieldToCompanyOrgnisations();
+  }
+
+  /**
+   * Restrict the Owner field
+   * for the finiancial account form,
+   * only legal entity
+   *
+   * @return void
+   * @throws CRM_Core_Exception
+   */
+  private function restrictOwnerFieldToCompanyOrgnisations() {
+    $element = $this->form->getElement('contact_id');
+    $element->setAttribute('data-api-entity', 'Company');
+    $element->setAttribute('data-api-params', json_encode([
+      'search_field' => 'contact_id.organization_name',
+      'label_field' => 'contact_id.organization_name',
+    ]));
+    $element->setAttribute('data-select-params', json_encode(['minimumInputLength' => 0]));
+  }
+
+}

--- a/api/v3/Company.php
+++ b/api/v3/Company.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Company.get API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_company_get($params) {
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -181,6 +181,11 @@ function multicompanyaccounting_civicrm_buildForm($formName, &$form) {
     $hook = new CRM_Multicompanyaccounting_Hook_BuildForm_FinancialBatchSearch($form);
     $hook->run();
   }
+
+  if ($formName == 'CRM_Financial_Form_FinancialAccount') {
+    $hook = new CRM_Multicompanyaccounting_Hook_BuildForm_FinancialAccount($form);
+    $hook->run();
+  }
 }
 
 function multicompanyaccounting_civicrm_postProcess($formName, $form) {


### PR DESCRIPTION
## Overview
This PR restrict the owner field in the financial account edit/add form to show only the organisation registered as company.


![Screenshot 2022-12-16 162023](https://user-images.githubusercontent.com/115652455/208107997-20249d2f-6f07-4cb6-9614-330bc5ca8416.jpg)

## Before
The owner field will show dropdown menu and you can select any organisation even if it's not a company
![Screenshot 2022-12-16 162340](https://user-images.githubusercontent.com/115652455/208108130-fba9e9ac-053b-4393-b26c-b00dc052be15.jpg)

## After
The owner field will show dropdown menu and it will show you only the organisations registered as companies.
![Screenshot 2022-12-16 162044](https://user-images.githubusercontent.com/115652455/208108173-a8bfadc9-9edd-456f-982d-a12a70a83b9f.jpg)

## Technical Details
The financial account owner organisation field is added here: https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Financial/Form/FinancialAccount.php#L75-L78
using `addEntityRef` method (https://docs.civicrm.org/dev/en/latest/framework/quickform/entityref/), in this PR I've adjusted it to use the Company entity instead by:

1- Creating an API V3 endpoint for the Company entity, given `addEntityRef` only work on API V3 at the time being.
2- Since with the BuildForm hook, I adjusted the API parameters for the  `addEntityRef` to use the Company API end point I defined in step 1.