### PR TITLE
CIWEMB-74: Use Owner Organisation invoice template and tokens

### DIFF
--- a/CRM/Multicompanyaccounting/CustomGroup/ContributionOwnerOrganisation.php
+++ b/CRM/Multicompanyaccounting/CustomGroup/ContributionOwnerOrganisation.php
@@ -1,0 +1,38 @@
+<?php
+
+class CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation {
+
+  /**
+   * Sets the contribution owner organisation.
+   *
+   * @param int $contributionId
+   * @param int $ownerOrganizationId
+   * @return void
+   */
+  public static function setOwnerOrganisation($contributionId, $ownerOrganizationId) {
+    $query = "INSERT INTO civicrm_value_multicompanyaccounting_ownerorg (entity_id, owner_organization)
+                    VALUES ({$contributionId}, {$ownerOrganizationId})
+                    ON DUPLICATE KEY UPDATE owner_organization = {$ownerOrganizationId}";
+    CRM_Core_DAO::executeQuery($query);
+  }
+
+  /**
+   * Gets the company record associated
+   * with the contribution owner organisation.
+   *
+   * @param int $contributionId
+   * @return array
+   */
+  public static function getOwnerOrganisationCompany($contributionId) {
+    $OwnerOrgQuery = "SELECT contact.organization_name as name, company.* FROM civicrm_contribution cont
+                      INNER JOIN civicrm_value_multicompanyaccounting_ownerorg cont_ownerorg ON cont.id = cont_ownerorg.entity_id
+                      INNER JOIN multicompanyaccounting_company company ON cont_ownerorg.owner_organization = company.contact_id
+                      INNER JOIN civicrm_contact contact ON company.contact_id = contact.id
+                      WHERE cont.id = {$contributionId}
+                      LIMIT 1";
+    $contributionOwnerCompany = CRM_Core_DAO::executeQuery($OwnerOrgQuery);
+    $contributionOwnerCompany->fetch();
+    return $contributionOwnerCompany->toArray();
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplate.php
+++ b/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplate.php
@@ -1,0 +1,106 @@
+<?php
+
+use CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation as ContributionOwnerOrganisation;
+
+/**
+ * Provides separate invoicing template and tokens for each
+ * company (legal entity).
+ */
+class CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate {
+
+  private $templateParams;
+
+  private $contributionId;
+
+  private $contributionOwnerCompany;
+
+  public function __construct(&$templateParams) {
+    $this->templateParams = &$templateParams;
+    $this->contributionId = $templateParams['tplParams']['id'];
+  }
+
+  public function run() {
+    $this->contributionOwnerCompany = ContributionOwnerOrganisation::getOwnerOrganisationCompany($this->contributionId);
+    if (empty($this->contributionOwnerCompany)) {
+      return;
+    }
+
+    $this->useContributionOwnerOrganisationInvoiceTemplate();
+    $this->replaceDomainTokensWithOwnerOrganisationTokens();
+  }
+
+  /**
+   * Replaces the default civicrm invoice template
+   * by the one configured on the contribution owner
+   * organisation.
+   * This is possible because CiviCRM calls this hook
+   * before loading the template:
+   * https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Core/BAO/MessageTemplate.php#L418
+   *
+   * @return void
+   */
+  private function useContributionOwnerOrganisationInvoiceTemplate() {
+    $this->templateParams['messageTemplateID'] = $this->contributionOwnerCompany['invoice_template_id'];
+  }
+
+  /**
+   * Replaces the standard domain tokens in the
+   * invoice template, so they use the information
+   * from the contribution owner organisation instead
+   * of getting it from the domain record.
+   *
+   * @return void
+   */
+  private function replaceDomainTokensWithOwnerOrganisationTokens() {
+    $ownerOrganisationLocation = $this->getOwnerOrganisationLocation();
+
+    $replacementParams = [
+      'domain_organization' => $this->contributionOwnerCompany['name'],
+      'domain_street_address' => CRM_Utils_Array::value('street_address', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
+      'domain_supplemental_address_1' => CRM_Utils_Array::value('supplemental_address_1', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
+      'domain_supplemental_address_2' => CRM_Utils_Array::value('supplemental_address_2', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
+      'domain_supplemental_address_3' => CRM_Utils_Array::value('supplemental_address_3', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
+      'domain_city' => CRM_Utils_Array::value('city', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
+      'domain_postal_code' => CRM_Utils_Array::value('postal_code', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
+      'domain_state' => $ownerOrganisationLocation['address'][1]['state_province_abbreviation'],
+      'domain_country' => $ownerOrganisationLocation['address'][1]['country'],
+      'domain_email' => CRM_Utils_Array::value('email', CRM_Utils_Array::value('1', $ownerOrganisationLocation['email'])),
+      'domain_phone' => CRM_Utils_Array::value('phone', CRM_Utils_Array::value('1', $ownerOrganisationLocation['phone'])),
+    ];
+
+    $this->templateParams['tplParams'] = array_merge($this->templateParams['tplParams'], $replacementParams);
+  }
+
+  /**
+   * Gets the owner organisation location details.
+   *
+   * This method as well as `replaceDomainTokensWithOwnerOrganisationTokens`
+   * are to some degree copied from CiviCRM core
+   * to make sure the experience is kinda similar between sites
+   * that have this extension enabled and the sites that don't:
+   * https://github.com/compucorp/civicrm-core/blob/5.39.1/CRM/Contribute/Form/Task/Invoice.php#L342-L356
+   *
+   * @return array
+   */
+  private function getOwnerOrganisationLocation() {
+    $ownerOrganisationId = $this->contributionOwnerCompany['contact_id'];
+    $locationDefaults = CRM_Core_BAO_Location::getValues(['contact_id' => $ownerOrganisationId]);
+
+    if (!empty($locationDefaults['address'][1]['state_province_id'])) {
+      $locationDefaults['address'][1]['state_province_abbreviation'] = CRM_Core_PseudoConstant::stateProvinceAbbreviation($locationDefaults['address'][1]['state_province_id']);
+    }
+    else {
+      $locationDefaults['address'][1]['state_province_abbreviation'] = '';
+    }
+
+    if (!empty($locationDefaults['address'][1]['country_id'])) {
+      $locationDefaults['address'][1]['country'] = CRM_Core_PseudoConstant::country($locationDefaults['address'][1]['country_id']);
+    }
+    else {
+      $locationDefaults['address'][1]['country'] = '';
+    }
+
+    return $locationDefaults;
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Hook/Post/ContributionCreation.php
+++ b/CRM/Multicompanyaccounting/Hook/Post/ContributionCreation.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation as ContributionOwnerOrganisation;
+
 class CRM_Multicompanyaccounting_Hook_Post_ContributionCreation {
 
   private $contributionId;
@@ -15,10 +17,7 @@ class CRM_Multicompanyaccounting_Hook_Post_ContributionCreation {
   private function updateOwnerOrganization() {
     $ownerOrganizationId = $this->getOwnerOrganizationId();
     if (!empty($ownerOrganizationId)) {
-      $updateQuery = "INSERT INTO civicrm_value_multicompanyaccounting_ownerorg (entity_id, owner_organization)
-                    VALUES ({$this->contributionId}, {$ownerOrganizationId})
-                    ON DUPLICATE KEY UPDATE owner_organization = {$ownerOrganizationId}";
-      CRM_Core_DAO::executeQuery($updateQuery);
+      ContributionOwnerOrganisation::setOwnerOrganisation($this->contributionId, $ownerOrganizationId);
     }
   }
 

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -158,6 +158,22 @@ function multicompanyaccounting_civicrm_navigationMenu(&$menu) {
   _membershipextras_civix_insert_navigation_menu($menu, 'Administer/CiviContribute', $companyMenuItem);
 }
 
+/**
+ * Implements hook_civicrm_alterMailParams().
+ */
+function multicompanyaccounting_civicrm_alterMailParams(&$params, $context) {
+  // 'contribution_invoice_receipt' is CiviCRM standard invoice template
+  if (empty($params['valueName']) || $params['valueName'] != 'contribution_invoice_receipt') {
+    return;
+  }
+
+  $hook = new CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate($params);
+  $hook->run();
+}
+
+/**
+ * Implements hook_civicrm_post().
+ */
 function multicompanyaccounting_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef) {
   if ($objectName === 'Contribution' && $op === 'create') {
     $hook = new CRM_Multicompanyaccounting_Hook_Post_ContributionCreation($objectId);
@@ -165,6 +181,9 @@ function multicompanyaccounting_civicrm_post(string $op, string $objectName, int
   }
 }
 
+/**
+ * Implements hook_civicrm__buildForm().
+ */
 function multicompanyaccounting_civicrm_buildForm($formName, &$form) {
   $addOrUpdate = ($form->getAction() & CRM_Core_Action::ADD) || ($form->getAction() & CRM_Core_Action::UPDATE);
   if ($formName == 'CRM_Financial_Form_FinancialBatch' && $addOrUpdate) {
@@ -183,6 +202,9 @@ function multicompanyaccounting_civicrm_buildForm($formName, &$form) {
   }
 }
 
+/**
+ * Implements hook_civicrm_postProcess().
+ */
 function multicompanyaccounting_civicrm_postProcess($formName, $form) {
   if ($formName == 'CRM_Financial_Form_FinancialBatch') {
     $hook = new CRM_Multicompanyaccounting_Hook_PostProcess_FinancialBatch($form);
@@ -190,6 +212,9 @@ function multicompanyaccounting_civicrm_postProcess($formName, $form) {
   }
 }
 
+/**
+ * Implements hook_civicrm_alterContent().
+ */
 function multicompanyaccounting_civicrm_alterContent(&$content, $context, $tplName, &$object) {
   if ($tplName == 'CRM/Financial/Page/BatchTransaction.tpl') {
     $hook = new CRM_Multicompanyaccounting_Hook_AlterContent_BatchTransaction($content);
@@ -197,6 +222,9 @@ function multicompanyaccounting_civicrm_alterContent(&$content, $context, $tplNa
   }
 }
 
+/**
+ * Implements hook_civicrm_selectWhereClause().
+ */
 function multicompanyaccounting_civicrm_selectWhereClause($entity, &$clauses) {
   $ownerOrganisationToFilterIds = CRM_Utils_Request::retrieve('multicompanyaccounting_owner_org_id', 'CommaSeparatedIntegers');
   if ($entity == 'Batch' && !empty($ownerOrganisationToFilterIds)) {

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -14,4 +14,12 @@ abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase implements
       ->apply();
   }
 
+  public function createOrganization($orgName) {
+    return civicrm_api3('Contact', 'create', [
+      'sequential' => 1,
+      'contact_type' => 'Organization',
+      'organization_name' => $orgName,
+    ])['values'][0];
+  }
+
 }

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplateTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplateTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplateTest extends BaseHeadlessTest {
+
+  public function testStandardInvoiceTemplateWillBeReplacedByContributionOwnerOrganisationTemplate() {
+    $organization = $this->createOrganization('testorg1');
+    $orgOneinvoiceTemplateId = $this->createMessageTemplate('testorg1');
+    $orgOneCompany = CRM_Multicompanyaccounting_BAO_Company::create(['contact_id' => $organization['id'], 'invoice_template_id' => $orgOneinvoiceTemplateId]);
+    $firstOrgContribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'receive_date' => '2022-11-11',
+      'total_amount' => 100,
+      'contact_id' => 1,
+    ]);
+    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($firstOrgContribution['id'], $orgOneCompany->contact_id);
+
+    $templateParams['messageTemplateID'] = NULL;
+    $templateParams['tplParams']['id'] = $firstOrgContribution['id'];
+    $alterInvoiceParams = new CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate($templateParams);
+    $alterInvoiceParams->run();
+
+    $this->assertEquals($orgOneinvoiceTemplateId, $templateParams['messageTemplateID']);
+  }
+
+  public function testDomainTokensWillBeReplacedByOwnerOrganisationDetails() {
+    $organization = $this->createOrganization('testorg1');
+    $orgOneInvoiceTemplateId = $this->createMessageTemplate('testorg1');
+
+    // set owner organisation address
+    $addressParams = [
+      'contact_id' => $organization['id'],
+      'location_type_id' => 'Billing',
+      'is_primary' => 1,
+      'street_address' => 'teststreet',
+      'supplemental_address_1' => 'testsupp1',
+      'supplemental_address_2' => 'testsupp2',
+      'supplemental_address_3' => 'testsupp3',
+      'city' => 'testcity',
+      'postal_code' => '0056',
+      'country_id' => 'GB',
+      'state_province_id' => 'Aberdeen City',
+    ];
+    civicrm_api3('Address', 'create', $addressParams);
+
+    // set owner organisation email
+    civicrm_api3('Email', 'create', [
+      'contact_id' => $organization['id'],
+      'email' => 'testorg1@example.com',
+    ]);
+
+    // set owner organisation phone
+    civicrm_api3('Phone', 'create', [
+      'contact_id' => $organization['id'],
+      'phone' => '079000005',
+    ]);
+
+    $orgOneCompany = CRM_Multicompanyaccounting_BAO_Company::create(['contact_id' => $organization['id'], 'invoice_template_id' => $orgOneInvoiceTemplateId]);
+    $firstOrgContribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'receive_date' => '2022-11-11',
+      'total_amount' => 100,
+      'contact_id' => 1,
+    ]);
+    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($firstOrgContribution['id'], $orgOneCompany->contact_id);
+
+    $templateParams['tplParams'] = NULL;
+    $templateParams['tplParams']['id'] = $firstOrgContribution['id'];
+    $alterInvoiceParams = new CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate($templateParams);
+    $alterInvoiceParams->run();
+    unset($templateParams['tplParams']['id']);
+
+    $expectedParams = [
+      'domain_organization' => 'testorg1',
+      'domain_street_address' => 'teststreet',
+      'domain_supplemental_address_1' => 'testsupp1',
+      'domain_supplemental_address_2' => 'testsupp2',
+      'domain_supplemental_address_3' => 'testsupp3',
+      'domain_city' => 'testcity',
+      'domain_postal_code' => '0056',
+      'domain_state' => 'ABE',
+      'domain_country' => 'United Kingdom',
+      'domain_email' => 'testorg1@example.com',
+      'domain_phone' => '079000005',
+    ];
+    $this->assertEquals($expectedParams, $templateParams['tplParams']);
+  }
+
+  private function createMessageTemplate($invoiceName) {
+    return civicrm_api3('MessageTemplate', 'create', [
+      'sequential' => 1,
+      'msg_title' => $invoiceName,
+      'workflow_name' => $invoiceName,
+      'is_active' => 1,
+    ])['id'];
+  }
+
+}

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/Post/ContributionCreationTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/Post/ContributionCreationTest.php
@@ -68,14 +68,6 @@ class CRM_Multicompanyaccounting_Hook_Post_ContributionCreationTest extends Base
     $this->assertEquals($secondOrg['id'], $contributionOwnerOrgId);
   }
 
-  private function createOrganization($orgName) {
-    return civicrm_api3('Contact', 'create', [
-      'sequential' => 1,
-      'contact_type' => 'Organization',
-      'organization_name' => $orgName,
-    ])['values'][0];
-  }
-
   private function updateFinancialAccountOwner($accountName, $newOwnerId) {
     return civicrm_api3('FinancialAccount', 'get', [
       'sequential' => 1,


### PR DESCRIPTION
## Before

CiviCRM has a single invoice template called "Contributions - Invoice" :

![2022-12-16 21_18_08-Message Templates _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/208190650-68fa6c99-1005-4ccc-ac6d-ffac6a18d8e2.png)

Where all invoices use this template, that template also contains the following tokens:

- domain_organization
- domain_street_address
- domain_supplemental_address_1
- domain_supplemental_address_2
- domain_supplemental_address_3
- domain_city
- domain_postal_code
- domain_state
- domain_country
- domain_email
- domain_phone

Which are resolved (evaluated) by looking into the address, phone and email of the contact record associated with the Domain entity (on all of our client sites we have only one domain, given we don't use Multi domain setups):
![2022-12-16 21_21_20-CiviCRM API v3 _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/208191150-a5f2cf53-5045-4b9c-9446-82aa0b3878f2.png)


## After

Here : https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/1 I've added the ability to set an invoice template for each company, while in this PR I make use of that configuration, where the invoice template that will be used for each contribution, will depend on the owner origination of that contribution, which ends up to be taken from the Company record associated with the organisation. Same goes for the tokens, all of the domain tokens mentioned above, are now replaced automatically by the address, phone and email of the owner organisation. 

## Example

Here is a contribution with the "owner organisation" id field set:
![2022-12-16 21_36_52-asem abu hussein _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/208193207-a2ad6d0b-92f7-4be5-8499-50117b87c135.png)

which is already configured as a company with a test mailing  template:

![2022-12-16 21_38_48-Company Listing _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/208193350-2685beb3-2978-4d95-aabd-bb94dfd6fc51.png)

the test mailing template used for the above company is a copy of the standard civicrm template but I changed the the title of the invoice from "INVOICE" to "TEST INVOICE".

without the work in this PR, trying to print or email an invoice for the above contribution will ignore the above message template, and uses the CiviCRM core one along with the Default Domain tokens:


![image](https://user-images.githubusercontent.com/6275540/208193568-e35dc519-b16c-425b-884a-e6edea651474.png)

While with the work in this PR, it will use the configured invoice template and the tokens will be fetched from the owner organisation :
![2022-12-16 21_43_20-INV_6 (15) pdf](https://user-images.githubusercontent.com/6275540/208194063-86ecc216-422a-492c-ab5d-914cfaf3b1b8.png)

![2022-12-16 21_45_30-Another Org _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/208194171-61c86b2d-712f-45d1-935e-05d0d7cfbf02.png)


## Technical Details

The work above was accomplished by implementing `hook_civicrm_alterMailParams`, which gets  here: https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Core/BAO/MessageTemplate.php#L418 after all the tokens been evaluated, but before the invoice template gets loaded, which allows to overwrite the token values and to change the message template that should be used for the invoice (instead of the default civicrm core one).

The hook implementation itself is straightforward, given that the contribution id is available to it already, thus I fetch the related owner_organisation to the contribution, and from the owner organisation I fetch the related Company record, which tells which invoice should be used.