### PR TITLE
CIWEMB-79: Add domain logo token for invoices

### DIFF
--- a/CRM/Multicompanyaccounting/CustomGroup/ContributionOwnerOrganisation.php
+++ b/CRM/Multicompanyaccounting/CustomGroup/ContributionOwnerOrganisation.php
@@ -24,7 +24,7 @@ class CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation {
    * @return array
    */
   public static function getOwnerOrganisationCompany($contributionId) {
-    $OwnerOrgQuery = "SELECT contact.organization_name as name, company.* FROM civicrm_contribution cont
+    $OwnerOrgQuery = "SELECT contact.organization_name as name, contact.image_URL as logo_url, company.* FROM civicrm_contribution cont
                       INNER JOIN civicrm_value_multicompanyaccounting_ownerorg cont_ownerorg ON cont.id = cont_ownerorg.entity_id
                       INNER JOIN multicompanyaccounting_company company ON cont_ownerorg.owner_organization = company.contact_id
                       INNER JOIN civicrm_contact contact ON company.contact_id = contact.id

--- a/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplate.php
+++ b/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplate.php
@@ -56,6 +56,7 @@ class CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate {
 
     $replacementParams = [
       'domain_organization' => $this->contributionOwnerCompany['name'],
+      'domain_logo' => CRM_Utils_Array::value('logo_url', $this->contributionOwnerCompany, ''),
       'domain_street_address' => CRM_Utils_Array::value('street_address', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
       'domain_supplemental_address_1' => CRM_Utils_Array::value('supplemental_address_1', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),
       'domain_supplemental_address_2' => CRM_Utils_Array::value('supplemental_address_2', CRM_Utils_Array::value('1', $ownerOrganisationLocation['address'])),


### PR DESCRIPTION
## Overview

As a continuation for the work here: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/6

a new token for the invoice template called `{$domain_logo}` is added, which will be resolved into the organization contact record photo that is associated with invoice to be printed, allowing for having different logo for different legal entities.

Here is an example:

Invoice template with "domain_logo" token:

![2022-12-20 12_10_40-Message Templates _ SOME PRETTY NAME](https://user-images.githubusercontent.com/6275540/208664258-595531a0-1481-4007-a8d2-7bd3d7ac7b72.png)

Here is an organization with a photo uploaded: 
![2022-12-20 12_11_18-Default Organization (default organisation) _ SOME PRETTY NAME](https://user-images.githubusercontent.com/6275540/208664360-5dfee7e4-4d87-4a17-a5cb-e22dd311e184.png)

and it is the owner organization  of this contribution:

![image](https://user-images.githubusercontent.com/6275540/208664447-64415902-706d-4acc-8481-0d755246b10c.png)


and here is the resulting invoice:
![image](https://user-images.githubusercontent.com/6275540/208664540-8b80db67-dfc2-4ec2-80d5-2a6b1ed5095e.png)
