### PR TITLE
CIWEMB-58: Restrict financial type to have multiple owners

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/FinancialTypeAccount.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/FinancialTypeAccount.php
@@ -35,30 +35,30 @@ class CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount {
     $existingFinancialAccountsData = $this->getExistingFinancialTypeAccountsCountAndOwner($financialTypeId);
     $selectedFinancialAccountOwnerOrganisationId = $this->getSelectedFinancialAccountOwnerOrganisationId();
 
-    // Allowing changing the owner organisation if there is only one financial account.
+    // Allow changing the owner organisation if there is only one financial account.
     if ($isUpdateAction && $existingFinancialAccountsData['accounts_count'] === 1) {
       return;
     }
-    // Allow add financial account type if there is no assigned financial accounts
+    // Allow adding a financial account type if there are no financial accounts assigned
     if ($isAddAction && $existingFinancialAccountsData['accounts_count'] === 0) {
       return;
     }
 
     if ($selectedFinancialAccountOwnerOrganisationId !== $existingFinancialAccountsData['owner_organisation_id']) {
-      $this->errors['financial_account_id'] = ts('You cannot have multiple Owner for a Financial Type');
+      $this->errors['financial_account_id'] = ts('You cannot have multiple Owners for a Financial Type');
     }
   }
 
   /**
    * Gets the Financial Accounts based on financial type id sent by the form
    */
-  private function getExistingFinancialTypeAccountsCountAndOwner($financial_type_id) {
+  private function getExistingFinancialTypeAccountsCountAndOwner($financialTypeId) {
     $result = \Civi\Api4\EntityFinancialAccount::get()
       ->addSelect('COUNT(*) AS count', 'financial_account.contact_id')
       ->setJoin([['FinancialAccount AS financial_account', 'INNER', NULL, ['financial_account_id', '=', 'financial_account.id']]])
       ->setGroupBy(['financial_account.contact_id'])
       ->addWhere('entity_table', '=', 'civicrm_financial_type')
-      ->addWhere('entity_id', '=', $financial_type_id)
+      ->addWhere('entity_id', '=', $financialTypeId)
       ->execute()
       ->first();
 

--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/FinancialTypeAccount.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/FinancialTypeAccount.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Form Validation on editing or assign a financial account for a financial type
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount {
+
+  private $form;
+  private $errors;
+  private $fields;
+
+  public function __construct(&$form, &$errors, &$fields) {
+    $this->form = $form;
+    $this->errors = &$errors;
+    $this->fields = &$fields;
+  }
+
+  public function validate() {
+    $this->validateFinancialAccountOrganisation();
+  }
+
+  /**
+   * Validates the financial type account form
+   * when editing or assigning a new account
+   */
+  private function validateFinancialAccountOrganisation() {
+    $isAddAction = $this->form->getAction() === CRM_Core_Action::ADD;
+    $isUpdateAction = $this->form->getAction() === CRM_Core_Action::UPDATE;
+    $isFormActionToValidate = $isAddAction || $isUpdateAction;
+    if (!$isFormActionToValidate) {
+      return;
+    }
+
+    $financialTypeId = $this->form->getVar('_aid');
+    $existingFinancialAccountsData = $this->getExistingFinancialTypeAccountsCountAndOwner($financialTypeId);
+    $selectedFinancialAccountOwnerOrganisationId = $this->getSelectedFinancialAccountOwnerOrganisationId();
+
+    // Allowing changing the owner organisation if there is only one financial account.
+    if ($isUpdateAction && $existingFinancialAccountsData['accounts_count'] === 1) {
+      return;
+    }
+    // Allow add financial account type if there is no assigned financial accounts
+    if ($isAddAction && $existingFinancialAccountsData['accounts_count'] === 0) {
+      return;
+    }
+
+    if ($selectedFinancialAccountOwnerOrganisationId !== $existingFinancialAccountsData['owner_organisation_id']) {
+      $this->errors['financial_account_id'] = ts('You cannot have multiple Owner for a Financial Type');
+    }
+  }
+
+  /**
+   * Gets the Financial Accounts based on financial type id sent by the form
+   */
+  private function getExistingFinancialTypeAccountsCountAndOwner($financial_type_id) {
+    $result = \Civi\Api4\EntityFinancialAccount::get()
+      ->addSelect('COUNT(*) AS count', 'financial_account.contact_id')
+      ->setJoin([['FinancialAccount AS financial_account', 'INNER', NULL, ['financial_account_id', '=', 'financial_account.id']]])
+      ->setGroupBy(['financial_account.contact_id'])
+      ->addWhere('entity_table', '=', 'civicrm_financial_type')
+      ->addWhere('entity_id', '=', $financial_type_id)
+      ->execute()
+      ->first();
+
+    return [
+      'accounts_count' => $result['count'] ?? 0,
+      'owner_organisation_id' => $result['financial_account.contact_id'] ?? 0,
+    ];
+  }
+
+  /**
+   * Gets the owner of the financial account from the submitted fields
+   */
+  private function getSelectedFinancialAccountOwnerOrganisationId() {
+    $result = \Civi\Api4\FinancialAccount::get()
+      ->addSelect('contact_id')
+      ->addWhere('id', '=', $this->fields['financial_account_id'])
+      ->execute()
+      ->first();
+
+    return $result['contact_id'];
+  }
+
+}

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -254,4 +254,8 @@ function multicompanyaccounting_civicrm_validateForm($formName, &$fields, &$file
       $membershipType->validate();
     }
   }
+  if ($formName === 'CRM_Financial_Form_FinancialTypeAccount') {
+    $membershipType = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($form, $errors, $fields);
+    $membershipType->validate();
+  }
 }

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/FinancialTypeAccountTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/FinancialTypeAccountTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccountTest extends BaseHeadlessTest {
+
+  private $form;
+
+  private $financialTypeId;
+
+  private $donationFinancialAccountId;
+
+  private $accountsReceivableFinancialAccountId;
+
+  public function setUp() {
+    $this->form = new CRM_Financial_Form_FinancialTypeAccount();
+
+    $this->financialTypeId = civicrm_api3('FinancialType', 'create', [
+      'sequential' => 1,
+      'name' => "Test",
+    ])['id'];
+
+    $this->donationFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
+      'return' => "id",
+      'name' => "Donation",
+    ]);
+
+    $this->accountsReceivableFinancialAccountId = civicrm_api3('FinancialAccount', 'getvalue', [
+      'return' => "id",
+      'name' => "Accounts Receivable",
+    ]);
+
+    $firstOwnerOrgId = $this->createCompany(1)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $firstOwnerOrgId);
+
+    $this->updateFinancialAccountOwner('Accounts Receivable', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Banking Fees', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Premiums', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner(strtolower("Test"), $firstOwnerOrgId);
+  }
+
+  public function testUpdateFinancialTypeAccountWithFinancialAccountOwnerMatchesTheAssignedOwnerWillPassValidation() {
+    $errors = [];
+    $fields = [];
+    $this->form->setAction(CRM_Core_Action::UPDATE);
+    $this->form->setVar('_aid', $this->financialTypeId);
+    $fields['financial_account_id'] = $this->donationFinancialAccountId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($this->form, $errors, $fields);
+    $hook->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testUpdateFinancialTypeAccountWithFinancialAccountOwnerNotMatchesTheAssignedOwnerWillFailValidation() {
+    $errors = [];
+    $fields = [];
+    $this->form->setAction(CRM_Core_Action::UPDATE);
+    $this->form->setVar('_aid', $this->financialTypeId);
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $secondOwnerOrgId);
+    $fields['financial_account_id'] = $this->donationFinancialAccountId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($this->form, $errors, $fields);
+    $hook->validate();
+    $this->assertNotEmpty($errors['financial_account_id']);
+  }
+
+  public function testAddFinancialTypeAccountWithFinancialAccountOwnerMatchesTheAssignedOwnerWillPassValidation() {
+    $errors = [];
+    $fields = [];
+    $this->form->setAction(CRM_Core_Action::ADD);
+    $this->form->setVar('_aid', $this->financialTypeId);
+
+    $fields['financial_account_id'] = $this->donationFinancialAccountId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($this->form, $errors, $fields);
+    $hook->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testAddFinancialTypeAccountWithFinancialAccountOwnerNotMatchesTheAssignedOwnerWillFailValidation() {
+    $errors = [];
+    $fields = [];
+    $this->form->setAction(CRM_Core_Action::ADD);
+    $this->form->setVar('_aid', $this->financialTypeId);
+
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $secondOwnerOrgId);
+    $fields['financial_account_id'] = $this->donationFinancialAccountId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($this->form, $errors, $fields);
+    $hook->validate();
+    $this->assertNotEmpty($errors['financial_account_id']);
+  }
+
+  public function testUpdateFinancialTypeAccountWithOnlyOneAssignedFinancialAccountWillPassValidation() {
+    $errors = [];
+    $fields = [];
+    $this->deleteAllFinancialTypeAccountsExceptOne();
+
+    $this->form->setAction(CRM_Core_Action::UPDATE);
+    $this->form->setVar('_aid', $this->financialTypeId);
+    $fields['financial_account_id'] = $this->accountsReceivableFinancialAccountId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($this->form, $errors, $fields);
+    $hook->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testAddFinancialTypeAccountWithNoAssignedFinancialAccountWillPassValidation() {
+    $errors = [];
+    $fields = [];
+    $this->deleteAllFinancialTypeAccounts();
+
+    $this->form->setAction(CRM_Core_Action::ADD);
+    $this->form->setVar('_aid', $this->financialTypeId);
+    $fields['financial_account_id'] = $this->accountsReceivableFinancialAccountId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($this->form, $errors, $fields);
+    $hook->validate();
+    $this->assertEmpty($errors);
+  }
+
+  /**
+   * This function used to test the case where
+   * we have only one assigned financial account type
+   * since CiviCRM by default assign 4 account for the created financial type
+   */
+  private function deleteAllFinancialTypeAccountsExceptOne() {
+    \Civi\Api4\EntityFinancialAccount::delete()
+      ->addWhere('entity_table', '=', 'civicrm_financial_type')
+      ->addWhere('entity_id', '=', $this->financialTypeId)
+      ->addWhere('financial_account_id', '!=', $this->accountsReceivableFinancialAccountId)
+      ->execute();
+  }
+
+  private function deleteAllFinancialTypeAccounts() {
+    \Civi\Api4\EntityFinancialAccount::delete()
+      ->addWhere('entity_table', '=', 'civicrm_financial_type')
+      ->addWhere('entity_id', '=', $this->financialTypeId)
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
## Overview
Restrict financial type to have multiple owners by prevent assigning and editing financial account with different owner

## Before
![BEFORE_CIWEMB-58](https://user-images.githubusercontent.com/115652455/208692640-d6f9b508-3e61-426c-a4a2-43fe604e10ee.gif)

## After
![AFTER_CIWEMB-58](https://user-images.githubusercontent.com/115652455/208692654-1438b17b-23ca-49f8-b9f7-4016a93f9081.gif)

## Technical Details
This implmented using `hook_civicrm_validateForm` and given that the form for edit and assign is the same `CRM_Financial_Form_FinancialTypeAccount`
In the `validateForm` the code does the following:
- gets the owner of the financial account that submitted by the form
- checks it with the owner of financial accounts that is already assigned
-  if they not have the same value and we are not editing only one financial account we show an error.


