### PR TITLE
CIWEMB-66: Calculate and set contributions invoice number

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/Post/ContributionCreation.php
+++ b/CRM/Multicompanyaccounting/Hook/Post/ContributionCreation.php
@@ -6,36 +6,207 @@ class CRM_Multicompanyaccounting_Hook_Post_ContributionCreation {
 
   private $contributionId;
 
+  private $ownerOrganizationId;
+
+  private static $paymentPlanOwnerOrganization = [];
+
+  private static $incomeAccountRelationId;
+
   public function __construct($contributionId) {
     $this->contributionId = $contributionId;
-  }
 
-  public function run() {
-    $this->updateOwnerOrganization();
-  }
-
-  private function updateOwnerOrganization() {
-    $ownerOrganizationId = $this->getOwnerOrganizationId();
-    if (!empty($ownerOrganizationId)) {
-      ContributionOwnerOrganisation::setOwnerOrganisation($this->contributionId, $ownerOrganizationId);
+    if (empty(self::$incomeAccountRelationId)) {
+      self::$incomeAccountRelationId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Income Account is' "));
     }
+
+    $this->setOwnerOrganizationId();
   }
 
   /**
-   * Gets the owner organization Id,
-   * which comes from the owner of the
-   * first line item income account.
+   * Sets the owner organization id based on
+   * 3 steps approach, which is needed to handle
+   * contributions being created from different
+   * screens and places.
+   *
+   * 1- If the contribution belongs to a payment plan
+   * created using the membership form or through autorenewal,
+   * then get it from the payment plan line items.
+   *
+   * 2- Otherwise we look into the contribution
+   * line items.
+   *
+   * 3- In cases where line items are created after the contribution,
+   * such as event registration or Webform submission, we get it directly
+   * from the contribution 'financial_type_id', though the event or
+   * the Webform has to be configured in certain way that can be found
+   * in this extension documentation.
+   *
+   * @return void
+   */
+  private function setOwnerOrganizationId() {
+    $ownerOrganizationId = NULL;
+
+    $contribution = $this->getContributionData();
+    if (!empty($contribution['contribution_recur_id'])) {
+      $ownerOrganizationId = $this->getOwnerOrganizationIdFromPaymentPlanLineItems($contribution['contribution_recur_id']);
+    }
+
+    if (empty($ownerOrganizationId)) {
+      $ownerOrganizationId = $this->getOwnerOrganizationIdFromContributionLineItems();
+    }
+
+    if (empty($ownerOrganizationId) && !empty($contribution['financial_type_id'])) {
+      $ownerOrganizationId = $this->getOwnerOrganizationIdFromContributionFinancialType($contribution['financial_type_id']);
+    }
+
+    $this->ownerOrganizationId = $ownerOrganizationId;
+  }
+
+  private function getContributionData() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['contribution_recur_id', 'financial_type_id'],
+      'id' => $this->contributionId,
+    ]);
+
+    if (empty($result['values'][0])) {
+      return NULL;
+    }
+
+    return $result['values'][0];
+  }
+
+  /**
+   * Gets the owner organization from the owner
+   * of the income account for the financial type of
+   * the recurring contribution active and renewable line items.
+   *
+   * And while this extension does not depend on "Membershipextras" extension,
+   * This method will only return result if "Membershipextras" is installed,
+   * which means only "Membershipextras" payment plans are supported.
+   *
+   * @param $recurContributionId
+   * @return mixed|string|null
+   */
+  private function getOwnerOrganizationIdFromPaymentPlanLineItems($recurContributionId) {
+    if (!empty(self::$paymentPlanOwnerOrganization[$recurContributionId])) {
+      return self::$paymentPlanOwnerOrganization[$recurContributionId];
+    }
+    self::$paymentPlanOwnerOrganization = [];
+
+    $incomeAccountRelationId = self::$incomeAccountRelationId;
+    $query = "SELECT fa.contact_id FROM civicrm_contribution_recur cr
+                            INNER JOIN membershipextras_subscription_line msl ON cr.id = msl.contribution_recur_id
+                            INNER JOIN civicrm_line_item li ON msl.line_item_id = li.id
+                            INNER JOIN civicrm_entity_financial_account efa ON li.financial_type_id = efa.entity_id AND efa.entity_table = 'civicrm_financial_type'
+                            INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
+                            WHERE cr.id = {$recurContributionId} AND efa.account_relationship = {$incomeAccountRelationId}
+                            AND msl.auto_renew = 1 AND msl.is_removed = 0
+                            ORDER BY msl.id DESC
+                            LIMIT 1";
+    $ownerOrgId = CRM_Core_DAO::singleValueQuery($query);
+
+    self::$paymentPlanOwnerOrganization[$recurContributionId] = $ownerOrgId;
+    return $ownerOrgId;
+  }
+
+  /**
+   * Gets the owner organization from the owner
+   * of the income account for the financial type of
+   * the contribution line items.
    *
    * @return string|null
    */
-  private function getOwnerOrganizationId() {
-    $incomeAccountRelationId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Income Account is' "));
-    $OwnerOrgQuery = "SELECT fa.contact_id FROM civicrm_line_item li
+  private function getOwnerOrganizationIdFromContributionLineItems() {
+    $incomeAccountRelationId = self::$incomeAccountRelationId;
+    $query = "SELECT fa.contact_id FROM civicrm_line_item li
                       INNER JOIN civicrm_entity_financial_account efa ON li.financial_type_id = efa.entity_id AND efa.entity_table = 'civicrm_financial_type'
                       INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
                       WHERE efa.account_relationship = {$incomeAccountRelationId} AND li.contribution_id = {$this->contributionId}
                       LIMIT 1";
-    return CRM_Core_DAO::singleValueQuery($OwnerOrgQuery);
+    return CRM_Core_DAO::singleValueQuery($query);
+  }
+
+  /**
+   * Gets the owner organization from the owner
+   * of the income account for the financial type of
+   * the contribution itself.
+   *
+   * @param $financialTypeId
+   * @return string|null
+   */
+  private function getOwnerOrganizationIdFromContributionFinancialType($financialTypeId) {
+    $incomeAccountRelationId = self::$incomeAccountRelationId;
+    $query = "SELECT fa.contact_id FROM civicrm_entity_financial_account efa
+                      INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
+                      WHERE efa.entity_id = {$financialTypeId} AND efa.entity_table = 'civicrm_financial_type' AND efa.account_relationship = {$incomeAccountRelationId}
+                      LIMIT 1";
+    return CRM_Core_DAO::singleValueQuery($query);
+  }
+
+  public function run() {
+    if (!empty($this->ownerOrganizationId)) {
+      $this->updateOwnerOrganization();
+      $this->setInvoiceNumber();
+    }
+    else {
+      // this will terminate the Contribution transaction in CiviCRM core, which will trigger a rollback and prevent the contribution
+      // from getting created.
+      throw new CRM_Core_Exception("Unable to set the owner organisation and the invoice number for the contribution with id: {$this->contributionId}.");
+    }
+  }
+
+  /**
+   * Stores the contribution owner organization.
+   *
+   * @return void
+   */
+  private function updateOwnerOrganization() {
+    ContributionOwnerOrganisation::setOwnerOrganisation($this->contributionId, $this->ownerOrganizationId);
+  }
+
+  /**
+   * Calculates and stores the contribution invoice
+   * number.
+   * The invoice number is calculated as the following:
+   * 1- Using the contribution owner organization, we get
+   * its related Company record, which contains the invoice
+   * prefix and next invoice number. The value is read using
+   * 'SELECT FOR UPDATE' to acquire a row level lock, to prevent
+   * any other contribution from using the same invoice number.
+   * The lock works because CiviCRM starts a transaction while
+   * creating the contribution, then at some transaction it triggers this
+   * hook, then later it commits the transaction. So the queries
+   * here runs as part of the contribution tran transaction.
+   *
+   * 2- Then the prefix is appended to the invoice number, this
+   * will be the contribution invoice number.
+   *
+   * 3- Then the next invoice number is incremented by one
+   * while padding zeros are preserved.
+   *
+   * 4- Finally the contribution invoice_number is set
+   * to the invoice number in from step 2.
+   *
+   * When the controls get back to CiviCRM core,
+   * CiviCRM will commit the transaction, and thus
+   * the lock on the Company row will be released.
+   *
+   * @return void
+   */
+  private function setInvoiceNumber() {
+    $companyRecord = CRM_Core_DAO::executeQuery("SELECT invoice_prefix, next_invoice_number FROM multicompanyaccounting_company WHERE contact_id = {$this->ownerOrganizationId} FOR UPDATE");
+    $companyRecord->fetch();
+
+    $invoiceNumber = $companyRecord->next_invoice_number;
+    if (!empty($companyRecord->invoice_prefix)) {
+      $invoiceNumber = $companyRecord->invoice_prefix . $companyRecord->next_invoice_number;
+    }
+
+    $invoiceNumberCharCount = strlen($companyRecord->next_invoice_number);
+    CRM_Core_DAO::executeQuery("UPDATE multicompanyaccounting_company SET next_invoice_number = LPAD((next_invoice_number + 1), {$invoiceNumberCharCount}, '0')  WHERE contact_id = {$this->ownerOrganizationId}");
+
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution SET invoice_number = '{$invoiceNumber}' WHERE id = {$this->contributionId}");
   }
 
 }

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -14,11 +14,36 @@ abstract class BaseHeadlessTest extends \PHPUnit\Framework\TestCase implements
       ->apply();
   }
 
-  public function createOrganization($orgName) {
-    return civicrm_api3('Contact', 'create', [
+  public function createCompany($companyNumber, $alternativeParams = []) {
+    $defaultParams = [
+      'name' => "testorg{$companyNumber}",
+      'invoice_template_id' => 1,
+      'invoice_prefix' => "INV{$companyNumber}_",
+      'next_invoice_number' => "00000{$companyNumber}",
+    ];
+
+    $params = $defaultParams;
+    if (!empty($alternativeParams)) {
+      $params = array_merge($defaultParams, $alternativeParams);
+    }
+
+    $orgId = civicrm_api3('Contact', 'create', [
       'sequential' => 1,
       'contact_type' => 'Organization',
-      'organization_name' => $orgName,
+      'organization_name' => $params['name'],
+    ])['id'];
+    unset($params['name']);
+    $params['contact_id'] = $orgId;
+
+    $company = CRM_Multicompanyaccounting_BAO_Company::create($params);
+    return $company->toArray();
+  }
+
+  public function updateFinancialAccountOwner($accountName, $newOwnerId) {
+    return civicrm_api3('FinancialAccount', 'get', [
+      'sequential' => 1,
+      'name' => $accountName,
+      'api.FinancialAccount.create' => ['id' => '$value.id', 'contact_id' => $newOwnerId],
     ])['values'][0];
   }
 

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplateTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/AlterMailParams/InvoiceTemplateTest.php
@@ -5,33 +5,34 @@
  */
 class CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplateTest extends BaseHeadlessTest {
 
+  private $company;
+
+  public function setUp() {
+    $this->company = $this->createCompany(1);
+    $this->updateFinancialAccountOwner('Donation', $this->company['contact_id']);
+  }
+
   public function testStandardInvoiceTemplateWillBeReplacedByContributionOwnerOrganisationTemplate() {
-    $organization = $this->createOrganization('testorg1');
-    $orgOneinvoiceTemplateId = $this->createMessageTemplate('testorg1');
-    $orgOneCompany = CRM_Multicompanyaccounting_BAO_Company::create(['contact_id' => $organization['id'], 'invoice_template_id' => $orgOneinvoiceTemplateId]);
-    $firstOrgContribution = civicrm_api3('Contribution', 'create', [
+    $contribution = civicrm_api3('Contribution', 'create', [
       'financial_type_id' => 'Donation',
       'receive_date' => '2022-11-11',
       'total_amount' => 100,
       'contact_id' => 1,
     ]);
-    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($firstOrgContribution['id'], $orgOneCompany->contact_id);
+    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($contribution['id'], $this->company['contact_id']);
 
     $templateParams['messageTemplateID'] = NULL;
-    $templateParams['tplParams']['id'] = $firstOrgContribution['id'];
+    $templateParams['tplParams']['id'] = $contribution['id'];
     $alterInvoiceParams = new CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate($templateParams);
     $alterInvoiceParams->run();
 
-    $this->assertEquals($orgOneinvoiceTemplateId, $templateParams['messageTemplateID']);
+    $this->assertEquals($this->company['invoice_template_id'], $templateParams['messageTemplateID']);
   }
 
   public function testDomainTokensWillBeReplacedByOwnerOrganisationDetails() {
-    $organization = $this->createOrganization('testorg1');
-    $orgOneInvoiceTemplateId = $this->createMessageTemplate('testorg1');
-
     // set owner organisation address
     $addressParams = [
-      'contact_id' => $organization['id'],
+      'contact_id' => $this->company['contact_id'],
       'location_type_id' => 'Billing',
       'is_primary' => 1,
       'street_address' => 'teststreet',
@@ -47,27 +48,26 @@ class CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplateTest extend
 
     // set owner organisation email
     civicrm_api3('Email', 'create', [
-      'contact_id' => $organization['id'],
+      'contact_id' => $this->company['contact_id'],
       'email' => 'testorg1@example.com',
     ]);
 
     // set owner organisation phone
     civicrm_api3('Phone', 'create', [
-      'contact_id' => $organization['id'],
+      'contact_id' => $this->company['contact_id'],
       'phone' => '079000005',
     ]);
 
-    $orgOneCompany = CRM_Multicompanyaccounting_BAO_Company::create(['contact_id' => $organization['id'], 'invoice_template_id' => $orgOneInvoiceTemplateId]);
-    $firstOrgContribution = civicrm_api3('Contribution', 'create', [
+    $contribution = civicrm_api3('Contribution', 'create', [
       'financial_type_id' => 'Donation',
       'receive_date' => '2022-11-11',
       'total_amount' => 100,
       'contact_id' => 1,
     ]);
-    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($firstOrgContribution['id'], $orgOneCompany->contact_id);
+    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($contribution['id'], $this->company['contact_id']);
 
     $templateParams['tplParams'] = NULL;
-    $templateParams['tplParams']['id'] = $firstOrgContribution['id'];
+    $templateParams['tplParams']['id'] = $contribution['id'];
     $alterInvoiceParams = new CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate($templateParams);
     $alterInvoiceParams->run();
     unset($templateParams['tplParams']['id']);
@@ -90,39 +90,28 @@ class CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplateTest extend
   }
 
   public function testDomainLogoTokenWillResolveToTheOrganisationImageURL() {
+    // update owner organisation profile image
     $fakeOrganisationImageURL = 'https://example.com/test1/test2/image.png';
-    $organization = civicrm_api3('Contact', 'create', [
+    civicrm_api3('Contact', 'create', [
       'sequential' => 1,
-      'contact_type' => 'Organization',
-      'organization_name' => 'testorg1',
+      'id' => $this->company['contact_id'],
       'image_URL' => $fakeOrganisationImageURL,
-    ])['values'][0];
-    $orgOneInvoiceTemplateId = $this->createMessageTemplate('testorg1');
+    ]);
 
-    $orgOneCompany = CRM_Multicompanyaccounting_BAO_Company::create(['contact_id' => $organization['id'], 'invoice_template_id' => $orgOneInvoiceTemplateId]);
-    $firstOrgContribution = civicrm_api3('Contribution', 'create', [
+    $contribution = civicrm_api3('Contribution', 'create', [
       'financial_type_id' => 'Donation',
       'receive_date' => '2022-11-11',
       'total_amount' => 100,
       'contact_id' => 1,
     ]);
-    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($firstOrgContribution['id'], $orgOneCompany->contact_id);
+    CRM_Multicompanyaccounting_CustomGroup_ContributionOwnerOrganisation::setOwnerOrganisation($contribution['id'], $this->company['contact_id']);
 
     $templateParams['tplParams'] = NULL;
-    $templateParams['tplParams']['id'] = $firstOrgContribution['id'];
+    $templateParams['tplParams']['id'] = $contribution['id'];
     $alterInvoiceParams = new CRM_Multicompanyaccounting_Hook_AlterMailParams_InvoiceTemplate($templateParams);
     $alterInvoiceParams->run();
 
     $this->assertEquals($fakeOrganisationImageURL, $templateParams['tplParams']['domain_logo']);
-  }
-
-  private function createMessageTemplate($invoiceName) {
-    return civicrm_api3('MessageTemplate', 'create', [
-      'sequential' => 1,
-      'msg_title' => $invoiceName,
-      'workflow_name' => $invoiceName,
-      'is_active' => 1,
-    ])['id'];
   }
 
 }


### PR DESCRIPTION
## Overview
This PR Overwrites CiviCRM core approach to set the Invoice Number based on the Contribution Id, to be based  instead on its Owner Organisation "Next Invoice Number", that is configured under the Company record, which was added here: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/1
  
## Before

Contribution "Invoice Number" is set automatically by CiviCRM if invoicing is enabled:

![2023-01-22 20_40_00-CiviContribute Component Settings _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/213939291-23715cfa-ed0f-47cd-b4ed-cad9d69751ce.png)

the Invoice ID = The Configured Prefix + The Contribution ID

![2023-01-22 20_41_59-View Contribution from assa dsdas _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/213939376-a7392238-a2c4-4b89-85f9-8ce56948a12d.png)


## After

The Contribution invoice number is now based on the configured "Invoice Prefix" + "Next Invoice Number" for the Owner organisation of the contribution.

For example, here we have the "Donation" Financial Type income account, where its owner is set to "Default Organization":

![111](https://user-images.githubusercontent.com/6275540/213940063-55f2e7d6-04cc-4868-8f55-4a4a1f342837.png)


Here a Company record is configured with the "Default Organization":

![image](https://user-images.githubusercontent.com/6275540/213940104-6abd035c-a520-47b9-ab62-a88ed2a8f5de.png)

And here, a Contribution is created with the "Donation" Financial Type:

![2023-01-22 20_54_42-ffsa fsfas _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/213939964-130f3998-6c9d-4817-b8f4-cf63b4fc70c4.png)

Which as we can see used the Invoice prefix and  next invoice number from the owner organisation related company record.

After the Contribution is created, the "Next Invoice Number" is incremented automatically:

![2023-01-22 21_00_23-](https://user-images.githubusercontent.com/6275540/213940189-0cf9b934-a120-488d-a3c0-15bcfe511989.png)


## Technical Details

To set the Invoice number using the "Next Invoice Number" from the Company entity, we would need something like this:

1- Get the contribution owner organization. 
2- Get the "Next Invoice Number" and "Invoice Prefix" from the Company record related to the owner organization.
3- Update the contribution "Invoice Number" using  "Invoice Prefix" + "Next Invoice Number".
4- Increment the "Next Invoice Number" on the company record by one.


And while doing that we need to ensure:

A- If we cannot set the Invoice number then the contribution should not be created.
B- And no two  or more contributions that belong to the same owner organizations should end up using the same invoice number, in case two or more contribution get created concurrently at the same time.

The good thing, contribution creation in Civi usually follows this format:

1- `CRM_Contribute_BAO_Contribution::create()` is called.
2- CiviCRM starts a database transaction: https://github.com/civicrm/civicrm-core/blob/5.51.3/CRM/Contribute/BAO/Contribution.php#L481
3- The Contribution parameters are calculated, the contribution and its other financial records are created, including line items.
4- Post Hook is triggered: https://github.com/civicrm/civicrm-core/blob/5.51.3/CRM/Contribute/BAO/Contribution.php#L239
5- CiviCRM commits the database transaction on success, or rollbacks  if any exception is thrown: https://github.com/civicrm/civicrm-core/blob/5.51.3/CRM/Contribute/BAO/Contribution.php#L487-L488


And given I've already used Post Hook in this PR: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/2  to get and store the contribution owner organization, I've added another step there to also use the owner organization to get the invoice number and also store it in the contribution, this was possible  while satisfying the conditions A and B above  because:

1- The post hook is triggered by CiviCRM inside the contribution creation transaction, and thus if this extension failed to get the contribution owner organization or failed to store the invoice number and throw an exception, then it will be caught by CiviCRM core and it will rollback the whole transaction preventing the contribution from getting created.

2- And because it happen as part of the contribution transaction, I am able to acquire a row lock on the Company table (using `SELECT FOR UPDATE`) that will only be released when the contribution transaction is committed or rolled-back, thus preventing any other contribution from using the same invoice number or incrementing it until then.


And while doing the above, I discovered an issue with my previous work here: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/2   about how I get the owner organization, apparently it does not work if:

- When the contribution(s) is/are getting created by Membershipextras extension as part of Payment plan or as part of autorenewal.
- Or The contribution is getting created from an Event registration
- Or it is getting created using a Webform.

In all of the above Cases, `skipLineItem` parameter is passed to the `CRM_Contribute_BAO_Contribution::create()` method,  which prevents CiviCRM from creating the line items, which we rely on to get the Owner organization in the Post Hook, the reason is they create the line items by themselves after the contribution is created, instead on relying on CiviCRM `CRM_Contribute_BAO_Contribution::create()` to create them, since these places prefer control over how the line items are created and other fields on the line items such as the "entity_table", "entity_id", "price_field_value_id" ..etc. And given I cannot ditch the idea of using the Post Hook because otherwise I cannot prevent CiviCRM from creating the contribution if this extension was not able to set the owner organization or the invoice number, I had to rely on different things other than the contribution line items, which are:

1- If the contribution belongs to a payment plan created using the membership form or through autorenewal,
then I get it from the payment plan line items, more on this below

2- If there is no recurring contribution set on the contribution, then I look at the contribution line items (which is what was already implemented in my previous PR). This will be the case for most standard contributions created by the contribution form, API, bulk actions or contribution pages (places that does not use skipLineItems parameter).

3- If not then I get it form the Contribution Financial Type, which is guaranteed to be there given it is a required field for the contribution, This is the case for Events and Webforms, but for this to work we need:

- For events: The Financial Type value is coming from the event configuration page (there is a required Financial Type field there), thus if the user who created the event wants to use a price set, then they need to make sure that its financial type income account owner as well as its price set, matches the one configured on the event configuration page. I will send another PR  anyway  to do that validation.

- For Webforms:  The Financial Type value is coming from the contribution page that is configured on the webform, so if the user is adding memberships to that webform, then they need to make sure the owner of the income account on contribution page financial type, matches the owner of the income accounts for the financial types configured on the selected membership types. Given it is hard to implement a validation on this, I will send a PR that adds a warning on the webform contribution tab telling the users about that. 



Now back to Payment Plans, when it come to payment plans, we need to differentiate between: 

1- Creating the first payment plan instalment (contribution).
2- Creating the upfront payment plan instalments (contributions), in case of Multi instalments payment plans such as monthly payment plans.
3- Renewing Payment plans.

In case 1, CiviCRM core creates such contribution, we only adjust its line item and other parameters after its creation in Membershipextras, but the contribution will by default have line items, so the code in this PR that uses the contribution line items to get the owner origination will be used for the 1st contribution in payment plan.  That is also the case because for the first contribution, no payment plan line items are created yet, nor the contribution_recur_id field is set on the contribution either.

In case 2, the `contribution_recur_id` field will be set, given they are created by Membershipextras which sets them, and Membershipextras at that point will already have the payment plan line items created (given they are created based on the first contribution line items), so the code in this PR that uses the payment plan line items will be used for such contributions. Same goes for Case 3 (autorenewal).

It worth noting though, this extension does not rely on Membershipextras, but our workflow in Compuco heavily relies on Membershipextras, So I had to put the Payment Plan handling code in this extension, which is kinda a hack, but a necessary one. Also keep in mind that Membershipextras relevant code will only be triggered if the `contribution_recur_id` is set on the contribution, which only happen for us at the moment for contribution created by Membershipextras, but if this changed in the future, then this part of the code has to change.


Here a rough graph showing how the stuff mentioned above work:

![2023-01-23 16_54_59-testmuli - Pencil](https://user-images.githubusercontent.com/6275540/214100922-bf1afadf-7243-4b39-b383-d0e7d4fe4b44.png)
