### PR TITLE
CIWEMB-149: Ensure consistent income account owner when creating Price Fields

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceField.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceField.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Form Validation on adding/editing price field or price field option.
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_PriceField {
+
+  private $form;
+  private $fields;
+  private $errors;
+
+  public function __construct(&$form, &$fields, &$errors) {
+    $this->form = $form;
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+  }
+
+  public function validate() {
+    $this->validateConsistentIncomeAccountOwner();
+  }
+
+  /**
+   * Validates if the owner organization of the income
+   * account for the selected financial type(s), match
+   * the owner of the income account for the parent
+   * price set financial type.
+   *
+   * @return void
+   */
+  private function validateConsistentIncomeAccountOwner() {
+    $selectedFinancialTypesOwnerOrganizations = $this->getSelectedFinancialTypesOwnerOrganizations();
+    if (empty($selectedFinancialTypesOwnerOrganizations)) {
+      return;
+    }
+
+    if (count($selectedFinancialTypesOwnerOrganizations) > 1) {
+      $this->errors['financial_type_id'] = 'The owner of the income account for the financial types you selected do not match';
+      return;
+    }
+
+    $priceSetOwnerOrganization = $this->getPriceSetOwnerOrganization();
+    if ($selectedFinancialTypesOwnerOrganizations[0] != $priceSetOwnerOrganization) {
+      $this->errors['financial_type_id'] = 'The owner of the income account for the financial type you selected, does not match the owner of the income account for price set financial type.';
+    }
+  }
+
+  private function getSelectedFinancialTypesOwnerOrganizations() {
+    $selectedFinancialTypes = $this->getSelectedFinancialTypes();
+    if (empty($selectedFinancialTypes)) {
+      return [];
+    }
+
+    return $this->getFinancialTypesOwnerOrganizationIds($selectedFinancialTypes);
+  }
+
+  /**
+   * Gets the financial types list
+   * that are selected by the user
+   * on the form.
+   *
+   * @return string
+   */
+  private function getSelectedFinancialTypes() {
+    $selectedFinancialTypes = [];
+    if (!empty($this->fields['html_type']) && $this->fields['html_type'] != 'Text') {
+      foreach ($this->fields['option_label'] as $index => $optionLabel) {
+        if (!empty($optionLabel)) {
+          $selectedFinancialTypes[] = $this->fields['option_financial_type_id'][$index];
+        }
+      }
+    }
+    else {
+      $selectedFinancialTypes = [$this->fields['financial_type_id']];
+    }
+
+    return implode(',', array_unique($selectedFinancialTypes));
+  }
+
+  /**
+   * Gets the owner organization
+   * for the income account associated
+   * with financial type of the parent
+   * price set of this price field.
+   *
+   * @return string|null
+   */
+  private function getPriceSetOwnerOrganization() {
+    $priceSetId = CRM_Utils_Request::retrieve('sid', 'Positive');
+    $priceSetFinancialTypeId = civicrm_api3('PriceSet', 'getvalue', [
+      'return' => 'financial_type_id',
+      'id' => $priceSetId,
+    ]);
+
+    return $this->getFinancialTypesOwnerOrganizationIds($priceSetFinancialTypeId)[0];
+  }
+
+  private function getFinancialTypesOwnerOrganizationIds($financialTypes) {
+    $orgIds = [];
+
+    $incomeAccountRelationId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Income Account is' "));
+    $query = "SELECT fa.contact_id FROM civicrm_entity_financial_account efa
+              INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
+              WHERE efa.entity_id IN ({$financialTypes}) AND efa.entity_table = 'civicrm_financial_type' AND efa.account_relationship = {$incomeAccountRelationId}";
+    $results = CRM_Core_DAO::executeQuery($query);
+    while ($results->fetch()) {
+      $orgIds[] = $results->contact_id;
+    }
+
+    return array_unique($orgIds);
+  }
+
+}

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -237,3 +237,13 @@ function multicompanyaccounting_civicrm_selectWhereClause($entity, &$clauses) {
     $hook->filterBasedOnOwnerOrganisations($ownerOrganisationToFilterIds);
   }
 }
+
+/**
+ * Implements hook_civicrm_validateForm().
+ */
+function multicompanyaccounting_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+  if (in_array($formName, ['CRM_Price_Form_Field', 'CRM_Price_Form_Option'])) {
+    $membershipType = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceField($form, $fields, $errors);
+    $membershipType->validate();
+  }
+}

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceFieldTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceFieldTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_PriceFieldTest extends BaseHeadlessTest {
+
+  private $testPriceSetId;
+
+  private $donationFinancialTypeId;
+
+  private $memberDuesFinancialTypeId;
+
+  public function setUp() {
+    $this->testPriceSetId = civicrm_api3('PriceSet', 'create', [
+      'sequential' => 1,
+      'title' => 'test',
+      'extends' => 'CiviContribute',
+      'financial_type_id' => 'Donation',
+    ])['id'];
+    $_REQUEST['sid'] = $this->testPriceSetId;
+
+    $this->donationFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Donation',
+    ]);
+
+    $this->memberDuesFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Member Dues',
+    ]);
+
+    // We set the owner of the two financial types used in tests to match by default.
+    $firstOwnerOrgId = $this->createCompany(1)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Member Dues', $firstOwnerOrgId);
+  }
+
+  public function tearDown() {
+    unset($_REQUEST['sid']);
+  }
+
+  public function testCreatingTextPriceFieldWithOwnerAccountMatchesThePriceSetWillPassValidation() {
+    $form = NULL;
+    $fields = [];
+    $errors = [];
+
+    $fields['html_type'] = 'Text';
+    $fields['financial_type_id'] = $this->memberDuesFinancialTypeId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceField($form, $fields, $errors);
+    $hook->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testCreatingTextPriceFieldWithOwnerAccountNotMatchingThePriceSetWillFailValidation() {
+    $form = NULL;
+    $fields = [];
+    $errors = [];
+
+    $fields['html_type'] = 'Text';
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Member Dues', $secondOwnerOrgId);
+    $fields['financial_type_id'] = $this->memberDuesFinancialTypeId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceField($form, $fields, $errors);
+    $hook->validate();
+    $this->assertNotEmpty($errors['financial_type_id']);
+  }
+
+  public function testCreatingMultiOptionsPriceFieldWithOwnerAccountsMatchesThePriceSetWillPassValidation() {
+    $form = NULL;
+    $fields = [];
+    $errors = [];
+
+    $fields['html_type'] = 'Select';
+
+    $fields['option_label'][1] = 'test1';
+    $fields['option_financial_type_id'][1] = $this->donationFinancialTypeId;
+    $fields['option_label'][2] = 'test2';
+    $fields['option_financial_type_id'][2] = $this->memberDuesFinancialTypeId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceField($form, $fields, $errors);
+    $hook->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testCreatingMultiOptionsPriceFieldWithOwnerAccountsNotMatchingThePriceSetWillFailValidation() {
+    $form = NULL;
+    $fields = [];
+    $errors = [];
+
+    $fields['html_type'] = 'Select';
+
+    $fields['option_label'][1] = 'test1';
+    $fields['option_financial_type_id'][1] = $this->donationFinancialTypeId;
+
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Member Dues', $secondOwnerOrgId);
+    $fields['option_label'][2] = 'test2';
+    $fields['option_financial_type_id'][2] = $this->memberDuesFinancialTypeId;
+
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceField($form, $fields, $errors);
+    $hook->validate();
+    $this->assertNotEmpty($errors['financial_type_id']);
+  }
+
+}


### PR DESCRIPTION
## Overview
Adding validation to make sure the owners of the income account for the Price Fields financial types, matches the owner of the income account for the parent Price Set.

## Before

You can add Price Field or Fields to a price set, where the owner organization of the income account for the selected price fields financial types, does not match the owner organization of the income account for parent Price Set financial type. 

## After

Form validation on both the Price Field and Price Field Value forms to ensure the selected the owner of the income account for the selected financial type(s), match the owner organization of the income account for parent Price Set financial type. 


Examples:

Here we have two Financial Types, the owner of the income account for each one is different: 

![2023-01-25 12_10_44-Financial Types _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/214559989-d611963e-c0ca-4dfe-8228-eb46128e39eb.png)


![2023-01-25 12_10_01-Financial Types _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/214559875-693e0e03-98a9-4ca4-a81e-f72f004c6e4b.png)

And here is a Price Set with "Event Fee" set as financial type:

![2023-01-25 12_11_34-Edit test _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/214560190-e543d5cf-a877-4ff8-8560-b9ee6ebb5a25.png)

Here is when trying to add a Price Field to it with financial type with owner of the income account does not match the one on the parent price set:

![image](https://user-images.githubusercontent.com/6275540/214561066-142dcc77-cc13-423e-9a17-b415abc53cb6.png)

Here is when adding a Price Field with multiple values, and at least one of the financial types  income account owner does not match the parent price set:

![2023-01-25 12_17_19-test - Price Fields _ compuclient142sspv1](https://user-images.githubusercontent.com/6275540/214561452-34589de5-02ad-4a76-8a52-a4df734fdadd.png)

And here is one trying to update a Price Field Option after its creation, and  trying to change the financial type:

![image](https://user-images.githubusercontent.com/6275540/214561724-c796814a-a4c4-44fa-92c7-e56e0c310f6b.png)


## Technical Details


The hook_civicrm_validateForm is used on both Price Field and Price Field Option Forms, on the Price Field form, there are two possible cases:

1- The price field is of "Text" type, in such the Financial Type selected can be retrieved from the array key `financial_type_id` on the submitted form value, From it I get the income account and compare it with the one on the parent price set, the price set id is available through the Request parameters. Same applies when trying to edit the Price Option field, that is why the same validation class is used.

2- The Price field is of type other than "Text", which means it is a multi options price field, and each option can have its own financial type, in such case, and suppose you only added two options, CiviCRM will submit their values like this:

```
array(26) {
  'sid' =>
  string(1) "3"
  'fid' =>
  string(0) ""
  '_qf_default' =>
  string(10) "Field:next"
  '_qf_Field_next' =>
  string(1) "1"
  'label' =>
  string(3) "tes"
  'html_type' =>
  string(6) "Select"
  'price' =>
  string(0) ""
  'non_deductible_amount' =>
  string(0) ""
  'financial_type_id' =>
  string(1) "4"
  'option_label' =>
  array(15) {
    [1] =>
    string(3) "ada"
    [2] =>
    string(4) "dada"
    [3] =>
    string(0) ""
    [4] =>
    string(0) ""
    [5] =>
    string(0) ""
    [6] =>
    string(0) ""
    [7] =>
    string(0) ""
    [8] =>
    string(0) ""
    [9] =>
    string(0) ""
    [10] =>
    string(0) ""
    [11] =>
    string(0) ""
    [12] =>
    string(0) ""
    [13] =>
    string(0) ""
    [14] =>
    string(0) ""
    [15] =>
    string(0) ""
  }
  'option_amount' =>
  array(15) {
    [1] =>
    string(0) ""
    [2] =>
    string(0) ""
    [3] =>
    string(0) ""
    [4] =>
    string(0) ""
    [5] =>
    string(0) ""
    [6] =>
    string(0) ""
    [7] =>
    string(0) ""
    [8] =>
    string(0) ""
    [9] =>
    string(0) ""
    [10] =>
    string(0) ""
    [11] =>
    string(0) ""
    [12] =>
    string(0) ""
    [13] =>
    string(0) ""
    [14] =>
    string(0) ""
    [15] =>
    string(0) ""
  }
  'option_financial_type_id' =>
  array(15) {
    [1] =>
    string(1) "4"
    [2] =>
    string(1) "1"
    [3] =>
    string(1) "4"
    [4] =>
    string(1) "4"
    [5] =>
    string(1) "4"
    [6] =>
    string(1) "4"
    [7] =>
    string(1) "4"
    [8] =>
    string(1) "4"
    [9] =>
    string(1) "4"
    [10] =>
    string(1) "4"
    [11] =>
    string(1) "4"
    [12] =>
    string(1) "4"
    [13] =>
    string(1) "4"
    [14] =>
    string(1) "4"
    [15] =>
    string(1) "4"
  }
  'option_weight' =>
  array(15) {
    [1] =>
    string(1) "1"
    [2] =>
    string(1) "2"
    [3] =>
    string(1) "3"
    [4] =>
    string(1) "4"
    [5] =>
    string(1) "5"
    [6] =>
    string(1) "6"
    [7] =>
    string(1) "7"
    [8] =>
    string(1) "8"
    [9] =>
    string(1) "9"
    [10] =>
    string(2) "10"
    [11] =>
    string(2) "11"
    [12] =>
    string(2) "12"
    [13] =>
    string(2) "13"
    [14] =>
    string(2) "14"
    [15] =>
    string(2) "15"
  }
  'option_visibility_id' =>
  array(15) {
    [1] =>
    string(1) "1"
    [2] =>
    string(1) "1"
    [3] =>
    string(1) "1"
    [4] =>
    string(1) "1"
    [5] =>
    string(1) "1"
    [6] =>
    string(1) "1"
    [7] =>
    string(1) "1"
    [8] =>
    string(1) "1"
    [9] =>
    string(1) "1"
    [10] =>
    string(1) "1"
    [11] =>
    string(1) "1"
    [12] =>
    string(1) "1"
    [13] =>
    string(1) "1"
    [14] =>
    string(1) "1"
    [15] =>
    string(1) "1"
  }
  'option_status' =>
  array(15) {
    [1] =>
    string(1) "1"
    [2] =>
    string(1) "1"
    [3] =>
    string(1) "1"
    [4] =>
    string(1) "1"
    [5] =>
    string(1) "1"
    [6] =>
    string(1) "1"
    [7] =>
    string(1) "1"
    [8] =>
    string(1) "1"
    [9] =>
    string(1) "1"
    [10] =>
    string(1) "1"
    [11] =>
    string(1) "1"
    [12] =>
    string(1) "1"
    [13] =>
    string(1) "1"
    [14] =>
    string(1) "1"
    [15] =>
    string(1) "1"
  }
  'options_per_line' =>
  string(1) "1"
  'is_display_amounts' =>
  string(1) "1"
  'weight' =>
  string(1) "1"
  'help_pre' =>
  string(0) ""
  'help_post' =>
  string(0) ""
  'active_on' =>
  string(0) ""
  'expire_on' =>
  string(0) ""
  'visibility_id' =>
  string(1) "1"
  'is_active' =>
  string(1) "1"
}
```

The `financial_type_id` in this case is useless, and all the added options will be available inside arrays that start with `option_` starting with the index = 1 for the first option. There are 15 elements in the `option_` arrays, because CiviCRM Price Field form only allow for Maximum of 15 Price option to be added, and they are there inside the form but hidden unless the user adds more, so they get submitted by default, but their values inside the `option_` arrays are empty. Here I check the financial types for only the ones that are actually added by the user, I do that by checking if the `option_label` is set, given it is a required field for the price options that are to be added.