### PR TITLE
CIWEMB-56: Assign correct owner id on Financial Account forms

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialAccount.php
+++ b/CRM/Multicompanyaccounting/Hook/BuildForm/FinancialAccount.php
@@ -26,6 +26,7 @@ class CRM_Multicompanyaccounting_Hook_BuildForm_FinancialAccount {
     $element->setAttribute('data-api-params', json_encode([
       'search_field' => 'contact_id.organization_name',
       'label_field' => 'contact_id.organization_name',
+      'id_field' => 'contact_id',
     ]));
     $element->setAttribute('data-select-params', json_encode(['minimumInputLength' => 0]));
   }


### PR DESCRIPTION
## Before

When you set the "Owner" for any Financial account: 
![image](https://user-images.githubusercontent.com/6275540/219118337-126a701b-a249-44e0-8b75-a989a1cc664b.png)

Then it will look fine on the "Financial account" edit form, but if you assign it to a a financial type, then the owner there will look different on the financial type assigned  accounts page:

![image](https://user-images.githubusercontent.com/6275540/219118538-a321fc72-9f91-45d0-b2bb-3a6b3fd64680.png)


## After

The correct owner appears on the "Financial type" assigned accounts page:

![image](https://user-images.githubusercontent.com/6275540/219118937-69e5031b-6f4f-40d5-9667-134daaec1dfc.png)


## Technical details

As part of this PR: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/5/

the "Financial account" form was altered, so only organizations added as "Companies" will appear on the "Owner" field, by altering the `data-api-entity` property on the "Owner" field to "Company", but this ended up returning Company ids instead of contact ids, so when the form is submitted, a company id will be stored inside the financial account `contact_id` field, I fixed that by adding the `id_field` property which controls which field should be used and saved inside the db, and in this case I selected the `contact_id`, which corresponds to the Company.contact_id field. 