### PR TITLE
CIWEMB-171: Fix error when creating batch with no Owner Organisations

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/BuildForm/BatchTransaction.php
+++ b/CRM/Multicompanyaccounting/Hook/BuildForm/BatchTransaction.php
@@ -27,6 +27,9 @@ class CRM_Multicompanyaccounting_Hook_BuildForm_BatchTransaction {
     }
 
     $batchOwnerOrganisationIds = CRM_Multicompanyaccounting_BAO_BatchOwnerOrganisation::getByBatchId($batchId);
+    if (empty($batchOwnerOrganisationIds)) {
+      return;
+    }
 
     $fieldName = 'custom_' . $this->getContributionOwnerOrganisationFieldId();
     $defaults[$fieldName] = $batchOwnerOrganisationIds;


### PR DESCRIPTION
## Before

When creating a financial batch without selecting any Owner Organization:

![2023-02-15 22_08_23-New Financial Batch _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/219128492-6b7b5502-0bc8-472f-9674-86ef237c514d.png)

The following error appears:

![2023-02-15 22_09_31-Error _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/219128622-c7e46e42-99fe-47b9-b0e5-073d4217c0f4.png)


## After

Submitting a financial batch without selecting any Owner Organization works fine:

![image](https://user-images.githubusercontent.com/6275540/219128782-7cd71b61-32d5-4429-9737-15bf7d48b2b3.png)


![image](https://user-images.githubusercontent.com/6275540/219128823-0c653ef3-9807-468c-953d-89148fd315ed.png)



## Technical Details

Seems that trying to set the "Owner Organization"  custom field:
![image](https://user-images.githubusercontent.com/6275540/219129030-59d3b45d-07da-4ad8-9943-ebe31831cecb.png)

which is a multi select field, using an empty array as a default value does not work well with CiviCRM, and result in throwing the following error:

```
 php compuclientv2ssp_localhost:3942-drupal: 1676488358|192.168.160.1|http://compuclientv2ssp.localhost:3942|php|http://compuclientv2ssp.localhost:3942/civicrm/batchtransaction?reset=1&bid=17|http://compuclientv2ssp.localhost:3942/civicrm/financial/batch?reset=1&action=add|1||TypeError: htmlspecialchars(): Argument #1 ($string) must be of type string, array given in htmlspecialchars() (line 144 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/packages/HTML/Common.php).
 ```
 
 so I've changed the code that sets the default value for the "Owner organization" custom field, so it skips doing that if no "Owner organization" was selected.

