### PR TITLE
CIWEMB-191: Add validation on changing price set financial type

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/OwnerOrganizationRetriever.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/OwnerOrganizationRetriever.php
@@ -1,0 +1,28 @@
+<?php
+
+class CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationRetriever {
+
+  /**
+   * Gets a unique list of ids for the owner organizations of
+   * the input financial types.
+   *
+   * @param array $financialTypes
+   * @return array
+   */
+  public static function getFinancialTypesOwnerOrganizationIds($financialTypes) {
+    $financialTypesCommaSeperated = implode(',', array_unique($financialTypes));
+    $orgIds = [];
+
+    $incomeAccountRelationId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Income Account is' "));
+    $query = "SELECT fa.contact_id FROM civicrm_entity_financial_account efa
+              INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
+              WHERE efa.entity_id IN ({$financialTypesCommaSeperated}) AND efa.entity_table = 'civicrm_financial_type' AND efa.account_relationship = {$incomeAccountRelationId}";
+    $results = CRM_Core_DAO::executeQuery($query);
+    while ($results->fetch()) {
+      $orgIds[] = $results->contact_id;
+    }
+
+    return array_unique($orgIds);
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/OwnerOrganizationValidator.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/OwnerOrganizationValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationRetriever as OwnerOrganizationRetriever;
+
 /**
  * Owner Organization Form Validation
  */
@@ -50,7 +52,7 @@ class CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator {
       return [];
     }
 
-    return $this->getFinancialTypesOwnerOrganizationIds($selectedFinancialTypes);
+    return OwnerOrganizationRetriever::getFinancialTypesOwnerOrganizationIds($selectedFinancialTypes);
   }
 
   /**
@@ -58,7 +60,7 @@ class CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator {
    * that are selected by the user
    * on the form.
    *
-   * @return string
+   * @return array
    */
   private function getSelectedFinancialTypes() {
     $selectedFinancialTypes = [];
@@ -73,7 +75,7 @@ class CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator {
       $selectedFinancialTypes = [$this->fields['financial_type_id']];
     }
 
-    return implode(',', array_unique($selectedFinancialTypes));
+    return $selectedFinancialTypes;
   }
 
   /**
@@ -90,22 +92,7 @@ class CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator {
       'id' => $this->priceSetId,
     ]);
 
-    return $this->getFinancialTypesOwnerOrganizationIds($priceSetFinancialTypeId)[0];
-  }
-
-  private function getFinancialTypesOwnerOrganizationIds($financialTypes) {
-    $orgIds = [];
-
-    $incomeAccountRelationId = key(CRM_Core_PseudoConstant::accountOptionValues('account_relationship', NULL, " AND v.name LIKE 'Income Account is' "));
-    $query = "SELECT fa.contact_id FROM civicrm_entity_financial_account efa
-              INNER JOIN civicrm_financial_account fa ON efa.financial_account_id = fa.id
-              WHERE efa.entity_id IN ({$financialTypes}) AND efa.entity_table = 'civicrm_financial_type' AND efa.account_relationship = {$incomeAccountRelationId}";
-    $results = CRM_Core_DAO::executeQuery($query);
-    while ($results->fetch()) {
-      $orgIds[] = $results->contact_id;
-    }
-
-    return array_unique($orgIds);
+    return OwnerOrganizationRetriever::getFinancialTypesOwnerOrganizationIds([$priceSetFinancialTypeId])[0];
   }
 
 }

--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceSetValidator.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceSetValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationRetriever as OwnerOrganizationRetriever;
+
+/**
+ * Price Set Form Validation
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_PriceSetValidator {
+
+  private $fields;
+  private $errors;
+  private $priceSetId;
+
+  public function __construct(&$fields, &$errors, $priceSetId) {
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+    $this->priceSetId = $priceSetId;
+  }
+
+  public function validate() {
+    $this->validateConsistentIncomeAccountOwner();
+  }
+
+  /**
+   * Validates if the owner organization of the income
+   * account for the selected financial type, matches
+   * the owner of the income account for the
+   * price fields under the price set.
+   *
+   * @return void
+   */
+  private function validateConsistentIncomeAccountOwner() {
+    $selectedPriceSetFinancialTypeOwnerOrganization = $this->getSelectedFinancialTypeOwnerOrganization();
+    if (empty($selectedPriceSetFinancialTypeOwnerOrganization)) {
+      return;
+    }
+
+    $priceSetFirstPriceFieldOwnerOrganization = $this->getPriceSetOwnerOrganizationForTheFirstChildPriceField();
+    if (empty($priceSetFirstPriceFieldOwnerOrganization)) {
+      return;
+    }
+
+    if ($selectedPriceSetFinancialTypeOwnerOrganization[0] != $priceSetFirstPriceFieldOwnerOrganization[0]) {
+      $this->errors['financial_type_id'] = 'The owner of the income account for the selected financial type does not match the owner of the income account for the financial types of the child price fields.';
+    }
+  }
+
+  private function getSelectedFinancialTypeOwnerOrganization() {
+    $selectedFinancialTypeId = $this->fields['financial_type_id'];
+    return OwnerOrganizationRetriever::getFinancialTypesOwnerOrganizationIds([$selectedFinancialTypeId]);
+  }
+
+  /**
+   * We get only the financial type for the
+   * first child price field, because we have validation
+   * on the price fields as well, so it is guaranteed
+   * they all have the same owner organization.
+   *
+   * @return array|null
+   */
+  private function getPriceSetOwnerOrganizationForTheFirstChildPriceField() {
+    $query = "SELECT pv.financial_type_id FROM civicrm_price_set ps
+              INNER JOIN civicrm_price_field pf ON ps.id = pf.price_set_id
+              INNER JOIN civicrm_price_field_value pv ON pf.id = pv.price_field_id
+              WHERE ps.id = {$this->priceSetId} LIMIT 1";
+    $firstChildPriceFieldFinancialTypeId = CRM_Core_DAO::singleValueQuery($query);
+    if (!$firstChildPriceFieldFinancialTypeId) {
+      return NULL;
+    }
+
+    return OwnerOrganizationRetriever::getFinancialTypesOwnerOrganizationIds([$firstChildPriceFieldFinancialTypeId]);
+  }
+
+}

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -244,18 +244,25 @@ function multicompanyaccounting_civicrm_selectWhereClause($entity, &$clauses) {
 function multicompanyaccounting_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   if (in_array($formName, ['CRM_Price_Form_Field', 'CRM_Price_Form_Option'])) {
     $parentPriceSetId = CRM_Utils_Request::retrieve('sid', 'Positive');
-    $membershipType = new CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator($fields, $errors, $parentPriceSetId);
-    $membershipType->validate();
+    $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator($fields, $errors, $parentPriceSetId);
+    $formValidator->validate();
   }
 
   if ($formName == 'CRM_Event_Form_ManageEvent_Fee') {
     if (!empty($fields['price_set_id'])) {
-      $membershipType = new CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator($fields, $errors, $fields['price_set_id']);
-      $membershipType->validate();
+      $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationValidator($fields, $errors, $fields['price_set_id']);
+      $formValidator->validate();
     }
   }
+
+  if ($formName == 'CRM_Price_Form_Set' && ($form->getAction() & CRM_Core_Action::UPDATE)) {
+    $priceSetId = $form->getEntityId();
+    $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceSetValidator($fields, $errors, $priceSetId);
+    $formValidator->validate();
+  }
+
   if ($formName === 'CRM_Financial_Form_FinancialTypeAccount') {
-    $membershipType = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($form, $errors, $fields);
-    $membershipType->validate();
+    $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($form, $errors, $fields);
+    $formValidator->validate();
   }
 }

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceSetValidatorTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/PriceSetValidatorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_PriceSetValidatorTest extends BaseHeadlessTest {
+
+  private $donationFinancialTypeId;
+
+  private $eventFeeFinancialTypeId;
+
+  private $memberDuesFinancialTypeId;
+
+  public function setUp() {
+    $this->donationFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Donation',
+    ]);
+    $this->eventFeeFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Event Fee',
+    ]);
+    $this->memberDuesFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Member Dues',
+    ]);
+
+    // Set the owner for 'Donation' and 'Event Fee' to be the same, where
+    // 'Member Dues' has different owner.
+    $firstOwnerOrgId = $this->createCompany(1)['contact_id'];
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Event Fee', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Member Dues', $secondOwnerOrgId);
+  }
+
+  public function testUpdatePriceSetWithFinancialTypeWithOwnerThatMatchChildPriceFieldsFinancialTypeOwnersShowsNoValidationError() {
+    $errors = [];
+    $fields = [];
+
+    $testPriceSetId = civicrm_api3('PriceSet', 'create', [
+      'sequential' => 1,
+      'title' => 'test',
+      'extends' => 'CiviContribute',
+      'financial_type_id' => 'Donation',
+    ])['id'];
+
+    civicrm_api3('PriceField', 'create', [
+      'label' => 'test1',
+      'name' => 'test1',
+      'price_set_id' => $testPriceSetId,
+      'html_type' => 'Text',
+      'financial_type_id' => $this->donationFinancialTypeId,
+      'option_label' => [1 => 'test1'],
+      'option_weight' => [1 => 1],
+      'option_amount' => [1 => 100],
+    ]);
+
+    $fields['financial_type_id'] = $this->eventFeeFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceSetValidator($fields, $errors, $testPriceSetId);
+    $hook->validate();
+
+    $this->assertEmpty($errors);
+  }
+
+  public function testUpdatePriceSetWithFinancialTypeWithOwnerThatDoesNotMatchChildPriceFieldsFinancialTypeOwnersShowsValidationError() {
+    $errors = [];
+    $fields = [];
+
+    $testPriceSetId = civicrm_api3('PriceSet', 'create', [
+      'sequential' => 1,
+      'title' => 'test',
+      'extends' => 'CiviContribute',
+      'financial_type_id' => 'Donation',
+    ])['id'];
+
+    $pF = civicrm_api3('PriceField', 'create', [
+      'label' => 'test1',
+      'name' => 'test1',
+      'price_set_id' => $testPriceSetId,
+      'html_type' => 'Text',
+      'financial_type_id' => $this->donationFinancialTypeId,
+      'option_label' => [1 => 'test1'],
+      'option_weight' => [1 => 1],
+      'option_amount' => [1 => 100],
+    ]);
+
+    $fields['financial_type_id'] = $this->memberDuesFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_PriceSetValidator($fields, $errors, $testPriceSetId);
+    $hook->validate();
+
+    $this->assertNotEmpty($errors['financial_type_id']);
+  }
+
+}


### PR DESCRIPTION
## Overview

Adding validation on the price set update form to prevent misconfiguring the Financial type.

## Before
In this PR: https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/10

I've added validation to ensure that admins cannot  change the financial type of a price field, unless the owner of the income account for the select financial type, matches the parent price set financial type owner.

But there is no kind of validation added that prevent the admin from changing the financial type of the price set to a one that has an owner that differs from its child price fields.


## After

Validation is added on the price set update form, which ensures that the owner of the financial type income account, matches the owner of the income account on the child price fields financial  types.

Here is an example price set getting changed to a financial type with owner that matches the child price fields :

![222](https://user-images.githubusercontent.com/6275540/222427974-8ab008b9-6134-474e-aee0-6842618751eb.gif)

And here is the same price set getting changed to a financial type with owner that does not matches the child price fields :

![111](https://user-images.githubusercontent.com/6275540/222428248-73d8ca99-244c-4c1c-889e-9bbcd96e5afc.gif)


## Technical Details

multicompanyaccounting_civicrm_validateForm is used here to add a new validation on the price set form `CRM_Price_Form_Set`, the validation compares the owner organization of the price set income account, with only the first child price field, given that due to the work I did here:  https://github.com/compucorp/io.compuco.multicompanyaccounting/pull/10 users are not able to configure child price fields with different owners (so all child price fields have the same owner), so it is guaranteed that any price field we do the validation against, should be enough.
