### PR TITLE
CIWEMB-178: Fix viewing contribution batch page

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/Config/APIWrapper/BatchListPage.php
+++ b/CRM/Multicompanyaccounting/Hook/Config/APIWrapper/BatchListPage.php
@@ -36,7 +36,7 @@ class CRM_Multicompanyaccounting_Hook_Config_APIWrapper_BatchListPage {
    * @param array $apiRequest
    * @param array $callsame
    */
-  public function enforcePermissionCheck(&$apiRequest, $callsame) {
+  public static function enforcePermissionCheck(&$apiRequest, $callsame) {
     $apiRequest['params']['check_permissions'] = 1;
 
     return $callsame($apiRequest);


### PR DESCRIPTION
## Overview
This PR solve the following problem where a contribution batch page gives an error

## Before
The contribution batch page shows an alert and the list of batches is not appearing

![aaa](https://user-images.githubusercontent.com/115652455/222759374-fa587fa5-b1bf-498d-9348-209a08ee7b31.gif)

## After
The contribution batch page working fine and the list of batches is appearing

![Screenshot 2023-03-03 163652](https://user-images.githubusercontent.com/115652455/222734007-3392e03b-d974-4b42-9ec8-e6c1945e388f.jpg)

## Technical Details
CiviCRM `wrapAPI` method: https://github.com/compucorp/io.compuco.multicompanyaccounting/blob/00c1129cdb0c1338fd0de8a4d18ca02d2c18b419/CRM/Multicompanyaccounting/Hook/Config/APIWrapper/BatchListPage.php#L24 calls the callback method statically, and while it works on PHP < 8.0 (where it just throws a warning) , it fails on PHP 8.0 
and throw a `TypeError`.

Here I fixed the issue by making `enforcePermissionCheck` method static.