### PR TITLE
CIWEMB-62: Prevent inconsistent financial type owners when editing contributions

### DIFF
--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/Contribution.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/Contribution.php
@@ -1,0 +1,55 @@
+<?php
+
+use CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationRetriever as OwnerOrganizationRetriever;
+
+/**
+ * Form Validation on contribution form.
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_Contribution {
+
+  private $contributionId;
+  private $errors;
+  private $fields;
+
+  public function __construct($contributionId, &$errors, &$fields) {
+    $this->contributionId = $contributionId;
+    $this->errors = &$errors;
+    $this->fields = &$fields;
+  }
+
+  public function validate() {
+    $this->validateConsistentIncomeAccountOwners();
+  }
+
+  /**
+   * Validates if the selected contribution
+   * financial type owner, or any of the
+   * added line item financial type owners matches
+   * the original contribution financial type owner.
+   *
+   * This is to prevent users from changing the owner
+   * organization of the contribution, or form them
+   * to have line items with inconsistent owners.
+   *
+   * @return void
+   */
+  private function validateConsistentIncomeAccountOwners() {
+    $selectedFinancialTypeId = $this->fields['financial_type_id'];
+    $currentFinancialTypeId = civicrm_api3('Contribution', 'getvalue', [
+      'return' => 'financial_type_id',
+      'id' => $this->contributionId,
+    ]);
+
+    $formFinancialTypeIds = [$currentFinancialTypeId, $selectedFinancialTypeId];
+    if (!empty($this->fields['item_financial_type_id'])) {
+      $lineItemsFinancialTypes = array_filter($this->fields['item_financial_type_id']);
+      $formFinancialTypeIds = array_merge($formFinancialTypeIds, $lineItemsFinancialTypes);
+    }
+
+    $formFinancialTypeOwners = OwnerOrganizationRetriever::getFinancialTypesOwnerOrganizationIds($formFinancialTypeIds);
+    if (count($formFinancialTypeOwners) > 1) {
+      $this->errors['financial_type_id'] = 'It is not possible to make the proposed changes to this contribution as the owner organisation of the contribution is not connected to the financial type of the proposed new line items. Please update the financial types.';
+    }
+  }
+
+}

--- a/CRM/Multicompanyaccounting/Hook/ValidateForm/LineItemEdit.php
+++ b/CRM/Multicompanyaccounting/Hook/ValidateForm/LineItemEdit.php
@@ -1,0 +1,45 @@
+<?php
+
+use CRM_Multicompanyaccounting_Hook_ValidateForm_OwnerOrganizationRetriever as OwnerOrganizationRetriever;
+
+/**
+ * Form Validation on line item edit form, that is provided by
+ * Lineitemedit extension.
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_LineItemEdit {
+
+  private $lineItemId;
+  private $errors;
+  private $fields;
+
+  public function __construct($lineItemId, &$errors, &$fields) {
+    $this->lineItemId = $lineItemId;
+    $this->errors = &$errors;
+    $this->fields = &$fields;
+  }
+
+  public function validate() {
+    $this->validateConsistentIncomeAccountOwners();
+  }
+
+  /**
+   * Validates if the financial type owner
+   * for the line item being edited matches
+   * the original line item financial type owner.
+   *
+   * @return void
+   */
+  private function validateConsistentIncomeAccountOwners() {
+    $selectedFinancialTypeId = $this->fields['financial_type_id'];
+    $currentFinancialTypeId = civicrm_api3('LineItem', 'getvalue', [
+      'return' => 'financial_type_id',
+      'id' => $this->lineItemId,
+    ]);
+
+    $financialTypeOwners = OwnerOrganizationRetriever::getFinancialTypesOwnerOrganizationIds([$currentFinancialTypeId, $selectedFinancialTypeId]);
+    if (count($financialTypeOwners) > 1) {
+      $this->errors['financial_type_id'] = 'It is not possible to make the proposed changes to this line item as the owner organisation of the contribution is not connected to the financial type of the proposed line item. Please update the financial types.';
+    }
+  }
+
+}

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -265,4 +265,16 @@ function multicompanyaccounting_civicrm_validateForm($formName, &$fields, &$file
     $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_FinancialTypeAccount($form, $errors, $fields);
     $formValidator->validate();
   }
+
+  if ($formName === 'CRM_Contribute_Form_Contribution' && ($form->getAction() & CRM_Core_Action::UPDATE)) {
+    $contributionId = $form->_id;
+    $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_Contribution($contributionId, $errors, $fields);
+    $formValidator->validate();
+  }
+
+  if ($formName == 'CRM_Lineitemedit_Form_Edit') {
+    $lineItemId = $form->_id;
+    $formValidator = new CRM_Multicompanyaccounting_Hook_ValidateForm_LineItemEdit($lineItemId, $errors, $fields);
+    $formValidator->validate();
+  }
 }

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/ContributionValidatorTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/ContributionValidatorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_ContributionValidatorTest extends BaseHeadlessTest {
+
+  private $donationFinancialTypeId;
+
+  private $eventFeeFinancialTypeId;
+
+  private $memberDuesFinancialTypeId;
+
+  public function setUp() {
+    $this->donationFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Donation',
+    ]);
+    $this->eventFeeFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Event Fee',
+    ]);
+    $this->memberDuesFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Member Dues',
+    ]);
+
+    $firstOwnerOrgId = $this->createCompany(1)['contact_id'];
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Event Fee', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Member Dues', $secondOwnerOrgId);
+  }
+
+  public function testAllowChangingContributionFinancialTypeToOneWithSameOwnerOrganization() {
+    $errors = [];
+    $fields = [];
+
+    $testContribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'receive_date' => '2022-11-11',
+      'total_amount' => 100,
+      'contact_id' => 1,
+    ]);
+
+    $fields['financial_type_id'] = $this->eventFeeFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_Contribution($testContribution['id'], $errors, $fields);
+    $hook->validate();
+
+    $this->assertEmpty($errors);
+  }
+
+  public function testPreventChangingContributionFinancialTypeToOneWithDifferentOwnerOrganization() {
+    $errors = [];
+    $fields = [];
+
+    $testContribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'receive_date' => '2022-11-11',
+      'total_amount' => 100,
+      'contact_id' => 1,
+    ]);
+
+    $fields['financial_type_id'] = $this->memberDuesFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_Contribution($testContribution['id'], $errors, $fields);
+    $hook->validate();
+
+    $this->assertNotEmpty($errors['financial_type_id']);
+  }
+
+  public function testAllowAddingContributionLineItemWithFinancialTypeWithSameOwnerOrganization() {
+    $errors = [];
+    $fields = [];
+
+    $testContribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'receive_date' => '2022-11-11',
+      'total_amount' => 100,
+      'contact_id' => 1,
+    ]);
+    $fields['financial_type_id'] = $this->donationFinancialTypeId;
+
+    $fields['item_financial_type_id'][0] = $this->eventFeeFinancialTypeId;
+    $fields['item_financial_type_id'][1] = $this->donationFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_Contribution($testContribution['id'], $errors, $fields);
+    $hook->validate();
+
+    $this->assertEmpty($errors);
+  }
+
+  public function testPreventAddingContributionLineItemWithFinancialTypeWithDifferentOwnerOrganization() {
+    $errors = [];
+    $fields = [];
+
+    $testContribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => 'Donation',
+      'receive_date' => '2022-11-11',
+      'total_amount' => 100,
+      'contact_id' => 1,
+    ]);
+    $fields['financial_type_id'] = $this->donationFinancialTypeId;
+
+    $fields['item_financial_type_id'][0] = $this->eventFeeFinancialTypeId;
+    $fields['item_financial_type_id'][1] = $this->memberDuesFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_Contribution($testContribution['id'], $errors, $fields);
+    $hook->validate();
+
+    $this->assertNotEmpty($errors['financial_type_id']);
+  }
+
+}

--- a/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/LineItemEditValidatorTest.php
+++ b/tests/phpunit/CRM/Multicompanyaccounting/Hook/ValidateForm/LineItemEditValidatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Multicompanyaccounting_Hook_ValidateForm_LineItemEditValidatorTest extends BaseHeadlessTest {
+
+  private $donationFinancialTypeId;
+
+  private $eventFeeFinancialTypeId;
+
+  private $memberDuesFinancialTypeId;
+
+  public function setUp() {
+    $this->donationFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Donation',
+    ]);
+    $this->eventFeeFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Event Fee',
+    ]);
+    $this->memberDuesFinancialTypeId = civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Member Dues',
+    ]);
+
+    $firstOwnerOrgId = $this->createCompany(1)['contact_id'];
+    $secondOwnerOrgId = $this->createCompany(2)['contact_id'];
+    $this->updateFinancialAccountOwner('Donation', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Event Fee', $firstOwnerOrgId);
+    $this->updateFinancialAccountOwner('Member Dues', $secondOwnerOrgId);
+  }
+
+  public function testAllowChangingLineItemToFinancialTypeWithSameOwnerOrganization() {
+    $errors = [];
+    $fields = [];
+
+    $testLineItem = civicrm_api3('LineItem', 'create', array(
+      'qty' => 1,
+      'entity_table' => 'civicrm_contribution',
+      'entity_id' => 1,
+      'financial_type_id' => $this->donationFinancialTypeId,
+      'unit_price' => 100,
+      'line_total' => 100,
+    ));
+
+    $fields['financial_type_id'] = $this->eventFeeFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_LineItemEdit($testLineItem['id'], $errors, $fields);
+    $hook->validate();
+
+    $this->assertEmpty($errors);
+  }
+
+  public function testPreventChangingLineItemToFinancialTypeWithDifferentOwnerOrganization() {
+    $errors = [];
+    $fields = [];
+
+    $testLineItem = civicrm_api3('LineItem', 'create', array(
+      'qty' => 1,
+      'entity_table' => 'civicrm_contribution',
+      'entity_id' => 1,
+      'financial_type_id' => $this->donationFinancialTypeId,
+      'unit_price' => 100,
+      'line_total' => 100,
+    ));
+
+    $fields['financial_type_id'] = $this->memberDuesFinancialTypeId;
+    $hook = new CRM_Multicompanyaccounting_Hook_ValidateForm_LineItemEdit($testLineItem['id'], $errors, $fields);
+    $hook->validate();
+
+    $this->assertNotEmpty($errors['financial_type_id']);
+  }
+
+}


### PR DESCRIPTION
## Overview
Adding validation on the contribution form to prevent editing it in a way that allow changing the owner organization or for it to have line items with inconsistent financial type owners.

## Before

Users can change the contribution financial type to a one with different owner than the original selected one when the contribution was created, they can also add new line items or edit them with financial type owner that differ from the owner of the contribution financial type owner.

## After

Users can no longer change the contribution financial type or add a new line item with financial type that differs from the contribution original financial type owner, thus technically preventing them from changing the contribution owner organization once its got created, they also can no longer edit existing line items to have a financial type with different owner from the originally chosen financial type.

Here, the original financial type is "Donation", when I tried to change it to "Test" which has different owner it shows a validation error, when I changed it to "Member Dues" which has the same owner as "Donation" it works fine:
![ezgif-1-ff557de4cf](https://user-images.githubusercontent.com/6275540/224955249-5e05cda8-adaf-4ea7-821b-8a6cee58d805.gif)


Here is the validation when the same thing is done but while trying to add line items:
![33333](https://user-images.githubusercontent.com/6275540/224957216-ca77c734-6cf5-492d-a797-0a18cd73acc4.gif)

And here when trying to edit an existing line item:
![45455454](https://user-images.githubusercontent.com/6275540/224957523-c95fbdc7-7619-40e6-80ff-08a850202e65.gif)


