### PR TITLE
CIWEMB-62: Fix extension installation on Compuclient 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.92 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.94 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.39.1
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/multicompanyaccounting.php
+++ b/multicompanyaccounting.php
@@ -174,7 +174,7 @@ function multicompanyaccounting_civicrm_alterMailParams(&$params, $context) {
 /**
  * Implements hook_civicrm_post().
  */
-function multicompanyaccounting_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef) {
+function multicompanyaccounting_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'Contribution' && $op === 'create') {
     $hook = new CRM_Multicompanyaccounting_Hook_Post_ContributionCreation($objectId);
     $hook->run();


### PR DESCRIPTION
## Overview

Installing the extension on Compuclient 2.0/PHP 8.0 sites throws the following error:

```
"TypeError: multicompanyaccounting_civicrm_post(): Argument #3 ($objectId) must be of type int, null given, called in /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/CRM/Utils/Hook.php on line 283 in multicompanyaccounting_civicrm_post() (line 177 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/io.compuco.multicompanyaccounting/multicompanyaccounting.php)."
```

which happens because I have type declarations on `hook_civicrm_post`, which gets called by CiviCRM Core during installation but without passing arguments that match the expected type for the $objectId argument. This used to throw an error on PHP 7.4 but on PHP 8.0 it throws an error instead, and that is why the installation fails on Compuclient 8.0 sites.

I fixed the problem by removing this hook type declarations, given we have no control over how and when CiviCRM core calls it.